### PR TITLE
Fix sevrice instead of service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A Rust SMPP library."
 authors = ["Jad K. Haddad <jadkhaddad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JadKHaddad/Rusmpp"
-readme = "README.md"
+readme = "Readme.md"
 keywords = ["smpp", "sms", "messaging", "networking", "protocol"]
 
 [dev-dependencies]

--- a/examples/submit_sm.rs
+++ b/examples/submit_sm.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         CommandStatus::EsmeRok,
         2,
         SubmitSm::builder()
-            .serivce_type(ServiceType::default())
+            .service_type(ServiceType::default())
             .source_addr_ton(Ton::Unknown)
             .source_addr_npi(Npi::Unknown)
             .source_addr(COctetString::from_str("A-Source")?)

--- a/src/codec/tests.rs
+++ b/src/codec/tests.rs
@@ -75,7 +75,7 @@ async fn do_codec() {
         CommandStatus::EsmeRok,
         2,
         SubmitSm::builder()
-            .serivce_type(ServiceType::default())
+            .service_type(ServiceType::default())
             .source_addr_ton(Ton::Unknown)
             .source_addr_npi(Npi::Unknown)
             .source_addr(COctetString::from_str("some_source").expect("Failed to create source"))

--- a/src/commands/pdu/broadcast_sm.rs
+++ b/src/commands/pdu/broadcast_sm.rs
@@ -38,7 +38,7 @@ impl_length_encode! {
         /// interface.
         ///
         /// Set to NULL for default MC settings.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Type of Number for source address.
         ///
         /// If not known, set to NULL (Unknown).
@@ -125,7 +125,7 @@ impl_length_encode! {
 impl BroadcastSm {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
@@ -160,7 +160,7 @@ impl BroadcastSm {
         ));
 
         Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -252,7 +252,7 @@ impl BroadcastSm {
 impl Default for BroadcastSm {
     fn default() -> Self {
         Self {
-            serivce_type: Default::default(),
+            service_type: Default::default(),
             source_addr_ton: Default::default(),
             source_addr_npi: Default::default(),
             source_addr: Default::default(),
@@ -281,7 +281,7 @@ impl DecodeWithLength for BroadcastSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
@@ -298,7 +298,7 @@ impl DecodeWithLength for BroadcastSm {
         let broadcast_frequency_interval = tri!(TLV::decode_from(reader));
 
         let tlvs_length = length
-            .saturating_sub(serivce_type.length())
+            .saturating_sub(service_type.length())
             .saturating_sub(source_addr_ton.length())
             .saturating_sub(source_addr_npi.length())
             .saturating_sub(source_addr.length())
@@ -317,7 +317,7 @@ impl DecodeWithLength for BroadcastSm {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -347,8 +347,8 @@ impl BroadcastSmBuilder {
         Self::default()
     }
 
-    pub fn serivce_type(mut self, serivce_type: ServiceType) -> Self {
-        self.inner.serivce_type = serivce_type;
+    pub fn service_type(mut self, service_type: ServiceType) -> Self {
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/cancel_broadcast_sm.rs
+++ b/src/commands/pdu/cancel_broadcast_sm.rs
@@ -37,7 +37,7 @@ impl_length_encode! {
         /// messages is desired.
         ///
         /// Otherwise set to NULL.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Message ID of the message to be cancelled. This must
         /// be the MC assigned Message ID of the original message.
         ///
@@ -70,7 +70,7 @@ impl_length_encode! {
 
 impl CancelBroadcastSm {
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         message_id: COctetString<1, 65>,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
@@ -83,7 +83,7 @@ impl CancelBroadcastSm {
             .collect::<Vec<TLV>>();
 
         Self {
-            serivce_type,
+            service_type,
             message_id,
             source_addr_ton,
             source_addr_npi,
@@ -125,14 +125,14 @@ impl DecodeWithLength for CancelBroadcastSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let message_id = tri!(COctetString::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
 
         let tlvs_length = length.saturating_sub(
-            serivce_type.length()
+            service_type.length()
                 + message_id.length()
                 + source_addr_ton.length()
                 + source_addr_npi.length()
@@ -142,7 +142,7 @@ impl DecodeWithLength for CancelBroadcastSm {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             message_id,
             source_addr_ton,
             source_addr_npi,
@@ -162,8 +162,8 @@ impl CancelBroadcastSmBuilder {
         Self::default()
     }
 
-    pub fn serivce_type(mut self, serivce_type: ServiceType) -> Self {
-        self.inner.serivce_type = serivce_type;
+    pub fn service_type(mut self, service_type: ServiceType) -> Self {
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/cancel_sm.rs
+++ b/src/commands/pdu/cancel_sm.rs
@@ -25,7 +25,7 @@ impl_length_encode! {
         /// if cancellation of a group of application
         /// service messages is desired.
         /// Otherwise set to NULL.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Message ID of the message to be
         /// cancelled. This must be the MC
         /// assigned Message ID of the original
@@ -98,7 +98,7 @@ impl_length_encode! {
 impl CancelSm {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         message_id: COctetString<1, 65>,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
@@ -108,7 +108,7 @@ impl CancelSm {
         destination_addr: COctetString<1, 21>,
     ) -> Self {
         Self {
-            serivce_type,
+            service_type,
             message_id,
             source_addr_ton,
             source_addr_npi,
@@ -133,7 +133,7 @@ impl Decode for CancelSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let message_id = tri!(COctetString::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
@@ -143,7 +143,7 @@ impl Decode for CancelSm {
         let destination_addr = tri!(COctetString::decode_from(reader));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             message_id,
             source_addr_ton,
             source_addr_npi,
@@ -166,7 +166,7 @@ impl CancelSmBuilder {
     }
 
     pub fn service_type(mut self, service_type: ServiceType) -> Self {
-        self.inner.serivce_type = service_type;
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/data_sm.rs
+++ b/src/commands/pdu/data_sm.rs
@@ -30,7 +30,7 @@ impl_length_encode! {
         ///
         /// Set to NULL for default MC
         /// settings.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Type of Number for source
         /// address.
         ///
@@ -74,7 +74,7 @@ impl_length_encode! {
 impl DataSm {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
@@ -92,7 +92,7 @@ impl DataSm {
             .collect::<Vec<TLV>>();
 
         Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -128,7 +128,7 @@ impl DecodeWithLength for DataSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
@@ -140,7 +140,7 @@ impl DecodeWithLength for DataSm {
         let data_coding = tri!(DataCoding::decode_from(reader));
 
         let tlvs_length = length.saturating_sub(
-            serivce_type.length()
+            service_type.length()
                 + source_addr_ton.length()
                 + source_addr_npi.length()
                 + source_addr.length()
@@ -155,7 +155,7 @@ impl DecodeWithLength for DataSm {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -181,7 +181,7 @@ impl DataSmBuilder {
     }
 
     pub fn service_type(mut self, service_type: ServiceType) -> Self {
-        self.inner.serivce_type = service_type;
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/deliver_sm.rs
+++ b/src/commands/pdu/deliver_sm.rs
@@ -36,7 +36,7 @@ impl_length_encode! {
         /// air interface.
         ///
         /// Set to NULL for default MC settings.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Type of Number for source address.
         pub source_addr_ton: Ton,
         /// Numbering Plan Indicator for source address.
@@ -101,7 +101,7 @@ impl_length_encode! {
 impl DeliverSm {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
@@ -128,7 +128,7 @@ impl DeliverSm {
         let sm_length = short_message.length() as u8;
 
         let mut submit_sm = Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -226,7 +226,7 @@ impl DecodeWithLength for DeliverSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
@@ -246,7 +246,7 @@ impl DecodeWithLength for DeliverSm {
         let short_message = tri!(OctetString::decode_from(reader, sm_length as usize));
 
         let tlvs_length = length.saturating_sub(
-            serivce_type.length()
+            service_type.length()
                 + source_addr_ton.length()
                 + source_addr_npi.length()
                 + source_addr.length()
@@ -269,7 +269,7 @@ impl DecodeWithLength for DeliverSm {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -302,8 +302,8 @@ impl DeliverSmBuilder {
         Self::default()
     }
 
-    pub fn serivce_type(mut self, serivce_type: ServiceType) -> Self {
-        self.inner.serivce_type = serivce_type;
+    pub fn service_type(mut self, service_type: ServiceType) -> Self {
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/submit_multi.rs
+++ b/src/commands/pdu/submit_multi.rs
@@ -33,7 +33,7 @@ impl_length_encode! {
         /// interface.
         ///
         /// Set to NULL for default MC settings.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Type of Number for source address.
         ///
         /// If not known, set to NULL (Unknown).
@@ -109,7 +109,7 @@ impl_length_encode! {
 impl SubmitMulti {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
@@ -135,7 +135,7 @@ impl SubmitMulti {
             .collect::<Vec<TLV>>();
 
         let mut submit_multi = Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -250,7 +250,7 @@ impl DecodeWithLength for SubmitMulti {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
@@ -272,7 +272,7 @@ impl DecodeWithLength for SubmitMulti {
         let short_message = tri!(OctetString::decode_from(reader, sm_length as usize));
 
         let tlvs_length = length
-            .saturating_sub(serivce_type.length())
+            .saturating_sub(service_type.length())
             .saturating_sub(source_addr_ton.length())
             .saturating_sub(source_addr_npi.length())
             .saturating_sub(source_addr.length())
@@ -293,7 +293,7 @@ impl DecodeWithLength for SubmitMulti {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -325,8 +325,8 @@ impl SubmitMultiBuilder {
         Default::default()
     }
 
-    pub fn serivce_type(mut self, serivce_type: ServiceType) -> Self {
-        self.inner.serivce_type = serivce_type;
+    pub fn service_type(mut self, service_type: ServiceType) -> Self {
+        self.inner.service_type = service_type;
         self
     }
 

--- a/src/commands/pdu/submit_sm.rs
+++ b/src/commands/pdu/submit_sm.rs
@@ -36,7 +36,7 @@ impl_length_encode! {
         /// air interface.
         ///
         /// Set to NULL for default MC settings.
-        pub serivce_type: ServiceType,
+        pub service_type: ServiceType,
         /// Type of Number for source address.
         pub source_addr_ton: Ton,
         /// Numbering Plan Indicator for source address.
@@ -99,7 +99,7 @@ impl_length_encode! {
 impl SubmitSm {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        serivce_type: ServiceType,
+        service_type: ServiceType,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
@@ -126,7 +126,7 @@ impl SubmitSm {
         let sm_length = short_message.length() as u8;
 
         let mut submit_sm = Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -224,7 +224,7 @@ impl DecodeWithLength for SubmitSm {
     where
         Self: Sized,
     {
-        let serivce_type = tri!(ServiceType::decode_from(reader));
+        let service_type = tri!(ServiceType::decode_from(reader));
         let source_addr_ton = tri!(Ton::decode_from(reader));
         let source_addr_npi = tri!(Npi::decode_from(reader));
         let source_addr = tri!(COctetString::decode_from(reader));
@@ -244,7 +244,7 @@ impl DecodeWithLength for SubmitSm {
         let short_message = tri!(OctetString::decode_from(reader, sm_length as usize));
 
         let tlvs_length = length.saturating_sub(
-            serivce_type.length()
+            service_type.length()
                 + source_addr_ton.length()
                 + source_addr_npi.length()
                 + source_addr.length()
@@ -267,7 +267,7 @@ impl DecodeWithLength for SubmitSm {
         let tlvs = tri!(Vec::<TLV>::decode_from(reader, tlvs_length));
 
         Ok(Self {
-            serivce_type,
+            service_type,
             source_addr_ton,
             source_addr_npi,
             source_addr,
@@ -300,8 +300,8 @@ impl SubmitSmBuilder {
         Self::default()
     }
 
-    pub fn serivce_type(mut self, serivce_type: ServiceType) -> Self {
-        self.inner.serivce_type = serivce_type;
+    pub fn service_type(mut self, service_type: ServiceType) -> Self {
+        self.inner.service_type = service_type;
         self
     }
 


### PR DESCRIPTION
Hey, while playing with your library I noticed a typo, all service are named sevrice
This pull request is to fix this and also the Cargo.toml that do not name the Readme correctly