### PR TITLE
make tests not dependent to an external server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ tokio-codec = [
 tracing = ["dep:tracing"] # Enables tracing support.
 
 [[example]]
+name = "client_server"
+path = "examples/client_server.rs"
+required-features = ["tokio-codec"]
+
+[[example]]
 name = "readme_example"
 path = "examples/readme_example.rs"
 required-features = ["tokio-codec"]

--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -1,0 +1,52 @@
+/// Demonstrate a SMPP server and a client sending an EnquireLink
+/// This example requires `tokio-codec` feature
+
+use futures::{SinkExt, StreamExt};
+use rusmpp::{
+    codec::command_codec::CommandCodec,
+    commands::{
+        command::Command,
+        pdu::Pdu,
+        types::{command_id::CommandId, command_status::CommandStatus},
+    },
+};
+use tokio::io::DuplexStream;
+use tokio_util::codec::Framed;
+
+async fn launch_server(server_stream: DuplexStream) -> Result<(), Box<dyn std::error::Error>> {
+    tokio::spawn(async move {
+        let mut framed = Framed::new(server_stream, CommandCodec {});
+
+        while let Some(Ok(command)) = framed.next().await {
+            if let CommandId::EnquireLink = command.command_id() {
+                println!("Server: EnquireLink received");
+                let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
+                framed.send(&response).await.unwrap();
+                println!("Server: EnquireLink response sent");
+                break;
+            }
+        }
+    });
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = tokio::io::duplex(4096);
+    launch_server(server_stream).await?;
+
+    let mut framed = Framed::new(client_stream, CommandCodec {});
+
+    let enquire_link_command = Command::new(CommandStatus::EsmeRok, 0, Pdu::EnquireLink);
+    println!("Client: EnquireLink sent");
+    framed.send(&enquire_link_command).await?;
+
+    while let Some(Ok(command)) = framed.next().await {
+        if let CommandId::EnquireLinkResp = command.command_id() {
+            println!("Client: EnquireLink response received");
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -1,5 +1,10 @@
-/// Demonstrate a SMPP server and a client sending an EnquireLink
-/// This example requires `tokio-codec` feature
+//! Demonstrate a SMPP server and a client sending an EnquireLink
+//! Run with
+//!
+//! ```not_rust
+//! cargo run --example client_server --features="tokio-codec"
+//! ```
+//!
 
 use futures::{SinkExt, StreamExt};
 use rusmpp::{
@@ -20,7 +25,11 @@ async fn launch_server(server_stream: DuplexStream) -> Result<(), Box<dyn std::e
         while let Some(Ok(command)) = framed.next().await {
             if let CommandId::EnquireLink = command.command_id() {
                 println!("Server: EnquireLink received");
-                let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
+                let response = Command::new(
+                    CommandStatus::EsmeRok,
+                    command.sequence_number,
+                    Pdu::EnquireLinkResp,
+                );
                 framed.send(&response).await.unwrap();
                 println!("Server: EnquireLink response sent");
                 break;

--- a/src/codec/command_codec.rs
+++ b/src/codec/command_codec.rs
@@ -38,10 +38,8 @@ use tokio_util::{
 ///
 ///         while let Some(Ok(command)) = framed.next().await {
 ///             if let CommandId::EnquireLink = command.command_id() {
-///                 println!("Server: EnquireLink received");
 ///                 let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
 ///                 framed.send(&response).await.unwrap();
-///                 println!("Server: EnquireLink response sent");
 ///                 break;
 ///             }
 ///         }
@@ -57,12 +55,10 @@ use tokio_util::{
 ///     let mut framed = Framed::new(client_stream, CommandCodec {});
 ///
 ///     let enquire_link_command = Command::new(CommandStatus::EsmeRok, 0, Pdu::EnquireLink);
-///     println!("Client: EnquireLink sent");
 ///     framed.send(&enquire_link_command).await?;
 ///
 ///     while let Some(Ok(command)) = framed.next().await {
 ///         if let CommandId::EnquireLinkResp = command.command_id() {
-///             println!("Client: EnquireLink response received");
 ///             break;
 ///         }
 ///     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,32 +14,20 @@
 //!         types::{command_id::CommandId, command_status::CommandStatus},
 //!     },
 //! };
-//! use std::net::SocketAddr;
-//! use tokio::net::{TcpListener, TcpStream};
-//! use tokio_util::codec::{FramedRead, FramedWrite};
+//! use tokio::io::DuplexStream;
+//! use tokio_util::codec::Framed;
 //!
-//! async fn launch_server() -> Result<(), Box<dyn std::error::Error>> {
-//!     let addr: SocketAddr = "127.0.0.1:2775".parse()?;
-//!     let listener = TcpListener::bind(addr).await?;
+//! async fn launch_server(server_stream: DuplexStream) -> Result<(), Box<dyn std::error::Error>> {
 //!     tokio::spawn(async move {
-//!         loop {
-//!             match listener.accept().await {
-//!                 Ok((socket, _)) => {
-//!                     tokio::spawn(async move {
-//!                         let (reader, writer) = socket.into_split();
-//!                         let mut framed_read = FramedRead::new(reader, CommandCodec {});
-//!                         let mut framed_write = FramedWrite::new(writer, CommandCodec {});
+//!         let mut framed = Framed::new(server_stream, CommandCodec {});
 //!
-//!                         while let Some(Ok(command)) = framed_read.next().await {
-//!                             if let CommandId::EnquireLink = command.command_id() {
-//!                                 let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
-//!                                 framed_write.send(&response).await.unwrap();
-//!                                 break;
-//!                             }
-//!                         }
-//!                     });
-//!                 }
-//!                 Err(e) => {}
+//!         while let Some(Ok(command)) = framed.next().await {
+//!             if let CommandId::EnquireLink = command.command_id() {
+//!                 println!("Server: EnquireLink received");
+//!                 let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
+//!                 framed.send(&response).await.unwrap();
+//!                 println!("Server: EnquireLink response sent");
+//!                 break;
 //!             }
 //!         }
 //!     });
@@ -48,21 +36,18 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     launch_server().await?;
-//!     let stream = TcpStream::connect("127.0.0.1:2775").await?;
-//! 
-//!     let (reader, writer) = stream.into_split();
-//!     let mut framed_read = FramedRead::new(reader, CommandCodec {});
-//!     let mut framed_write = FramedWrite::new(writer, CommandCodec {});
+//!     let (server_stream, client_stream) = tokio::io::duplex(4096);
+//!     launch_server(server_stream).await?;
+//!
+//!     let mut framed = Framed::new(client_stream, CommandCodec {});
 //!
 //!     let enquire_link_command = Command::new(CommandStatus::EsmeRok, 0, Pdu::EnquireLink);
+//!     println!("Client: EnquireLink sent");
+//!     framed.send(&enquire_link_command).await?;
 //!
-//!     // Send commands.
-//!     framed_write.send(&enquire_link_command).await?;
-//!
-//!     // Wait for responses.
-//!     while let Some(Ok(command)) = framed_read.next().await {
+//!     while let Some(Ok(command)) = framed.next().await {
 //!         if let CommandId::EnquireLinkResp = command.command_id() {
+//!             println!("Client: EnquireLink response received");
 //!             break;
 //!         }
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-// TODO: The doc test in failing on `ConnectionRefused` error. Create a Mock server to allow doc tests to pass. Remove the `ignore` tag.
-
 //! # Rusmpp
 //!
 //! Rust implementation of the [SMPP v5](https://smpp.org/SMPP_v5.pdf) protocol.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Rust implementation of the [SMPP v5](https://smpp.org/SMPP_v5.pdf) protocol.
 //!
-//! ```rust, ignore
+//! ```rust
 //! use futures::{SinkExt, StreamExt};
 //! use rusmpp::{
 //!     codec::command_codec::CommandCodec,
@@ -14,13 +14,43 @@
 //!         types::{command_id::CommandId, command_status::CommandStatus},
 //!     },
 //! };
-//! use tokio::net::TcpStream;
+//! use std::net::SocketAddr;
+//! use tokio::net::{TcpListener, TcpStream};
 //! use tokio_util::codec::{FramedRead, FramedWrite};
+//!
+//! async fn launch_server() -> Result<(), Box<dyn std::error::Error>> {
+//!     let addr: SocketAddr = "127.0.0.1:2775".parse()?;
+//!     let listener = TcpListener::bind(addr).await?;
+//!     tokio::spawn(async move {
+//!         loop {
+//!             match listener.accept().await {
+//!                 Ok((socket, _)) => {
+//!                     tokio::spawn(async move {
+//!                         let (reader, writer) = socket.into_split();
+//!                         let mut framed_read = FramedRead::new(reader, CommandCodec {});
+//!                         let mut framed_write = FramedWrite::new(writer, CommandCodec {});
+//!
+//!                         while let Some(Ok(command)) = framed_read.next().await {
+//!                             if let CommandId::EnquireLink = command.command_id() {
+//!                                 let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
+//!                                 framed_write.send(&response).await.unwrap();
+//!                                 break;
+//!                             }
+//!                         }
+//!                     });
+//!                 }
+//!                 Err(e) => {}
+//!             }
+//!         }
+//!     });
+//!     Ok(())
+//! }
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let stream = TcpStream::connect("34.242.18.250:2775").await?;
-//!
+//!     launch_server().await?;
+//!     let stream = TcpStream::connect("127.0.0.1:2775").await?;
+//! 
 //!     let (reader, writer) = stream.into_split();
 //!     let mut framed_read = FramedRead::new(reader, CommandCodec {});
 //!     let mut framed_write = FramedWrite::new(writer, CommandCodec {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,8 @@
 //!
 //!         while let Some(Ok(command)) = framed.next().await {
 //!             if let CommandId::EnquireLink = command.command_id() {
-//!                 println!("Server: EnquireLink received");
 //!                 let response = Command::new(CommandStatus::EsmeRok, command.sequence_number, Pdu::EnquireLinkResp);
 //!                 framed.send(&response).await.unwrap();
-//!                 println!("Server: EnquireLink response sent");
 //!                 break;
 //!             }
 //!         }
@@ -42,12 +40,10 @@
 //!     let mut framed = Framed::new(client_stream, CommandCodec {});
 //!
 //!     let enquire_link_command = Command::new(CommandStatus::EsmeRok, 0, Pdu::EnquireLink);
-//!     println!("Client: EnquireLink sent");
 //!     framed.send(&enquire_link_command).await?;
 //!
 //!     while let Some(Ok(command)) = framed.next().await {
 //!         if let CommandId::EnquireLinkResp = command.command_id() {
-//!             println!("Client: EnquireLink response received");
 //!             break;
 //!         }
 //!     }


### PR DESCRIPTION
Hi, a few doctests were dependent on a SMPP server which is not accessible (at least publicly). This pull request is to launch a local SMPP server instead to pass the test.
Also, it seems the test is the same in lib.rs and command_codec.rs. Maybe there is a reason to have both, otherwise one of them could be removed.
Regards

Matthieu