### PR TITLE
Feat/rusmpp/parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1521,7 @@ dependencies = [
  "arbitrary",
  "futures",
  "macrotest",
+ "pastey",
  "serde",
  "testcontainers",
  "tokio",

--- a/cspell.json
+++ b/cspell.json
@@ -38,6 +38,7 @@
         "Nsap",
         "oneshot",
         "Outbind",
+        "pastey",
         "pdus",
         "PLMN",
         "Pssd",
@@ -140,7 +141,8 @@
         "Ussn",
         "venv",
         "Wcmp",
-        "wireshark"
+        "wireshark",
+        "pastey"
     ],
     "ignorePaths": [
         "target",

--- a/rusmpp/Cargo.toml
+++ b/rusmpp/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.219", default-features = false, features = [
     "derive",
     "alloc",
 ], optional = true }
+pastey = "0.1.0"
 
 [features]
 default = ["tokio-codec"]

--- a/rusmpp/src/command/inner.rs
+++ b/rusmpp/src/command/inner.rs
@@ -127,28 +127,18 @@ impl Command {
         Default::default()
     }
 
-    #[inline]
-    pub fn into_parts(self) -> (CommandId, CommandStatus, u32, Option<Pdu>) {
-        (self.id, self.status, self.sequence_number, self.pdu)
-    }
-
     /// Creates a new command from it's parts.
     ///
     /// # Note
     ///
     /// This may create invalid commands. It's up to the caller to ensure that the [`CommandId`] and [`Pdu`] match.
     #[inline]
-    pub const fn from_parts(
-        id: CommandId,
-        status: CommandStatus,
-        sequence_number: u32,
-        pdu: Option<Pdu>,
-    ) -> Self {
+    pub fn from_parts(parts: CommandParts) -> Self {
         Self {
-            id,
-            status,
-            sequence_number,
-            pdu,
+            id: parts.id,
+            status: parts.status,
+            sequence_number: parts.sequence_number,
+            pdu: parts.pdu,
         }
     }
 }

--- a/rusmpp/src/command/mod.rs
+++ b/rusmpp/src/command/mod.rs
@@ -4,5 +4,7 @@ pub(super) mod builder;
 pub(super) mod command_id;
 pub(super) mod command_status;
 pub(super) mod inner;
+pub(super) mod parts;
 
 pub use builder::*;
+pub use parts::*;

--- a/rusmpp/src/command/parts.rs
+++ b/rusmpp/src/command/parts.rs
@@ -1,0 +1,1 @@
+pub use super::inner::CommandParts;

--- a/rusmpp/src/macros.rs
+++ b/rusmpp/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! create {
             )*
         }
     ) => {
-        $crate::create!(@create_struct_with_length_and_encode_and_test {
+        $crate::create!(@create_struct_with_parts_and_length_and_encode_and_test {
             $(#[$struct_meta])*
             $struct_vis $struct_ident
             $(
@@ -96,7 +96,7 @@ macro_rules! create {
             )*
         }
     ) => {
-        $crate::create!(@create_struct_with_length_and_encode_and_test {
+        $crate::create!(@create_struct_with_parts_and_length_and_encode_and_test {
             $(#[$struct_meta])*
             $struct_vis $struct_ident
             $(
@@ -146,7 +146,7 @@ macro_rules! create {
             )*
         }
     ) => {
-        $crate::create!(@create_struct_with_length_and_encode_and_test {
+        $crate::create!(@create_struct_with_parts_and_length_and_encode_and_test {
             $(#[$struct_meta])*
             $struct_vis $struct_ident
             $(
@@ -191,7 +191,7 @@ macro_rules! create {
             )*
         }
     ) => {
-        $crate::create!(@create_struct_with_length_and_encode_and_test {
+        $crate::create!(@create_struct_with_parts_and_length_and_encode_and_test {
             $(#[$struct_meta])*
             $struct_vis $struct_ident
             $(
@@ -251,7 +251,7 @@ macro_rules! create {
             )*
         }
     ) => {
-        $crate::create!(@create_struct_with_length_and_encode_and_test {
+        $crate::create!(@create_struct_with_parts_and_length_and_encode_and_test {
             $(#[$struct_meta])*
             $struct_vis $struct_ident
             $(
@@ -297,7 +297,7 @@ macro_rules! create {
         });
     };
 
-    (@create_struct_with_length_and_encode_and_test {
+    (@create_struct_with_parts_and_length_and_encode_and_test {
         $(#[$struct_meta:meta])*
         $struct_vis:vis $struct_ident:ident
         $(
@@ -311,6 +311,44 @@ macro_rules! create {
                 $(#[$field_attr])*
                 $field_vis $field_ident: $field_ty,
             )*
+        }
+
+        ::pastey::paste! {
+            #[derive(Debug)]
+            pub struct [<$struct_ident Parts>] {
+                $(
+                    pub $field_ident: $field_ty,
+                )*
+            }
+
+            impl [<$struct_ident Parts>] {
+                #[inline]
+                #[allow(clippy::too_many_arguments)]
+                pub const fn new($($field_ident: $field_ty),*) -> Self {
+                    Self {
+                        $(
+                            $field_ident,
+                        )*
+                    }
+                }
+
+                #[inline]
+                #[allow(unused_parens)]
+                pub fn raw(self) -> ($($field_ty),*) {
+                    ($(self.$field_ident),*)
+                }
+            }
+
+            impl $struct_ident {
+                #[inline]
+                pub fn into_parts(self) -> [<$struct_ident Parts>] {
+                    [<$struct_ident Parts>] {
+                        $(
+                            $field_ident: self.$field_ident,
+                        )*
+                    }
+                }
+            }
         }
 
         impl $crate::encode::Length for $struct_ident {

--- a/rusmpp/src/macros.rs
+++ b/rusmpp/src/macros.rs
@@ -266,6 +266,7 @@ macro_rules! create {
         });
     };
 
+    // Creates `<StructName>Parts` and implements `new`, `raw`, and `into_parts`.
     // Impl `Length`, `Encode` and `Decode` for a struct, based on its Into/From u8
     // The struct must be `Copy`, `Into<u8>` and `From<u8>`
     (
@@ -287,6 +288,13 @@ macro_rules! create {
             )*
         }
 
+        $crate::create!(@create_struct_parts {
+            $struct_ident
+            $(
+                $field_ident $field_ty,
+            )*
+        });
+
         $crate::create!(@repr{
             $struct_ident, u8
         });
@@ -297,22 +305,13 @@ macro_rules! create {
         });
     };
 
-    (@create_struct_with_parts_and_length_and_encode_and_test {
-        $(#[$struct_meta:meta])*
-        $struct_vis:vis $struct_ident:ident
+    // Creates `<StructName>Parts` and implements `new`, `raw`, and `into_parts`.
+    (@create_struct_parts {
+        $struct_ident:ident
         $(
-            $(#[$field_attr:meta])*
-            $field_vis:vis $field_ident:ident $field_ty:ty,
+            $field_ident:ident $field_ty:ty,
         )*
     }) => {
-        $(#[$struct_meta])*
-        $struct_vis struct $struct_ident {
-            $(
-                $(#[$field_attr])*
-                $field_vis $field_ident: $field_ty,
-            )*
-        }
-
         ::pastey::paste! {
             #[derive(Debug)]
             pub struct [<$struct_ident Parts>] {
@@ -350,6 +349,30 @@ macro_rules! create {
                 }
             }
         }
+    };
+
+    (@create_struct_with_parts_and_length_and_encode_and_test {
+        $(#[$struct_meta:meta])*
+        $struct_vis:vis $struct_ident:ident
+        $(
+            $(#[$field_attr:meta])*
+            $field_vis:vis $field_ident:ident $field_ty:ty,
+        )*
+    }) => {
+        $(#[$struct_meta])*
+        $struct_vis struct $struct_ident {
+            $(
+                $(#[$field_attr])*
+                $field_vis $field_ident: $field_ty,
+            )*
+        }
+
+        $crate::create!(@create_struct_parts {
+            $struct_ident
+            $(
+                $field_ident $field_ty,
+            )*
+        });
 
         impl $crate::encode::Length for $struct_ident {
             fn length(&self) -> usize {

--- a/rusmpp/src/pdus/mod.rs
+++ b/rusmpp/src/pdus/mod.rs
@@ -29,6 +29,33 @@ pub mod builders {
     pub use super::submit_sm_resp::SubmitSmRespBuilder;
 }
 
+pub mod parts {
+    pub use super::alert_notification::AlertNotificationParts;
+    pub use super::bind::{
+        BindAnyParts, BindReceiverParts, BindTransceiverParts, BindTransmitterParts,
+    };
+    pub use super::bind_resp::{
+        BindReceiverRespParts, BindTransceiverRespParts, BindTransmitterRespParts,
+    };
+    pub use super::broadcast_sm::BroadcastSmParts;
+    pub use super::broadcast_sm_resp::BroadcastSmRespParts;
+    pub use super::cancel_broadcast_sm::CancelBroadcastSmParts;
+    pub use super::cancel_sm::CancelSmParts;
+    pub use super::data_sm::DataSmParts;
+    pub use super::deliver_sm::DeliverSmParts;
+    pub use super::outbind::OutbindParts;
+    pub use super::query_broadcast_sm::QueryBroadcastSmParts;
+    pub use super::query_broadcast_sm_resp::QueryBroadcastSmRespParts;
+    pub use super::query_sm::QuerySmParts;
+    pub use super::query_sm_resp::QuerySmRespParts;
+    pub use super::replace_sm::ReplaceSmParts;
+    pub use super::sm_resp::{DataSmRespParts, DeliverSmRespParts};
+    pub use super::submit_multi::SubmitMultiParts;
+    pub use super::submit_multi_resp::SubmitMultiRespParts;
+    pub use super::submit_sm::SubmitSmParts;
+    pub use super::submit_sm_resp::SubmitSmRespParts;
+}
+
 mod alert_notification;
 pub use alert_notification::AlertNotification;
 

--- a/rusmpp/src/tlvs/tag.rs
+++ b/rusmpp/src/tlvs/tag.rs
@@ -5,7 +5,7 @@ crate::create! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
     #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
     #[cfg_attr(feature = "serde", derive(::serde::Serialize))]
-#[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
+    #[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
     pub enum TlvTag {
         /// The subcomponent in the destination device for which the user data is intended.
         ///

--- a/rusmpp/src/types/any_octet_string.rs
+++ b/rusmpp/src/types/any_octet_string.rs
@@ -69,6 +69,18 @@ impl AnyOctetString {
     }
 }
 
+impl From<Vec<u8>> for AnyOctetString {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+}
+
+impl From<AnyOctetString> for Vec<u8> {
+    fn from(value: AnyOctetString) -> Self {
+        value.bytes
+    }
+}
+
 impl core::fmt::Debug for AnyOctetString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("AnyOctetString")

--- a/rusmpp/src/types/c_octet_string.rs
+++ b/rusmpp/src/types/c_octet_string.rs
@@ -211,11 +211,9 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
     }
 }
 
-#[allow(clippy::from_over_into)]
-// We do not implement From<Vec<u8>> because bytes must be validated
-impl<const MIN: usize, const MAX: usize> Into<Vec<u8>> for COctetString<MIN, MAX> {
-    fn into(self) -> Vec<u8> {
-        self.bytes
+impl<const MIN: usize, const MAX: usize> From<COctetString<MIN, MAX>> for Vec<u8> {
+    fn from(value: COctetString<MIN, MAX>) -> Self {
+        value.bytes
     }
 }
 

--- a/rusmpp/src/types/c_octet_string.rs
+++ b/rusmpp/src/types/c_octet_string.rs
@@ -211,6 +211,14 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
     }
 }
 
+#[allow(clippy::from_over_into)]
+// We do not implement From<Vec<u8>> because bytes must be validated
+impl<const MIN: usize, const MAX: usize> Into<Vec<u8>> for COctetString<MIN, MAX> {
+    fn into(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
 impl<const MIN: usize, const MAX: usize> Default for COctetString<MIN, MAX> {
     fn default() -> Self {
         Self::empty()

--- a/rusmpp/src/types/empty_or_full_c_octet_string.rs
+++ b/rusmpp/src/types/empty_or_full_c_octet_string.rs
@@ -165,6 +165,14 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
     }
 }
 
+#[allow(clippy::from_over_into)]
+// We do not implement From<Vec<u8>> because bytes must be validated
+impl<const N: usize> Into<Vec<u8>> for EmptyOrFullCOctetString<N> {
+    fn into(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
 impl<const N: usize> core::fmt::Debug for EmptyOrFullCOctetString<N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EmptyOrFullCOctetString")

--- a/rusmpp/src/types/empty_or_full_c_octet_string.rs
+++ b/rusmpp/src/types/empty_or_full_c_octet_string.rs
@@ -165,11 +165,9 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
     }
 }
 
-#[allow(clippy::from_over_into)]
-// We do not implement From<Vec<u8>> because bytes must be validated
-impl<const N: usize> Into<Vec<u8>> for EmptyOrFullCOctetString<N> {
-    fn into(self) -> Vec<u8> {
-        self.bytes
+impl<const N: usize> From<EmptyOrFullCOctetString<N>> for Vec<u8> {
+    fn from(value: EmptyOrFullCOctetString<N>) -> Self {
+        value.bytes
     }
 }
 

--- a/rusmpp/src/types/octet_string.rs
+++ b/rusmpp/src/types/octet_string.rs
@@ -147,11 +147,9 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
     }
 }
 
-#[allow(clippy::from_over_into)]
-// We do not implement From<Vec<u8>> because bytes must be validated
-impl<const MIN: usize, const MAX: usize> Into<Vec<u8>> for OctetString<MIN, MAX> {
-    fn into(self) -> Vec<u8> {
-        self.bytes
+impl<const MIN: usize, const MAX: usize> From<OctetString<MIN, MAX>> for Vec<u8> {
+    fn from(value: OctetString<MIN, MAX>) -> Self {
+        value.bytes
     }
 }
 

--- a/rusmpp/src/types/octet_string.rs
+++ b/rusmpp/src/types/octet_string.rs
@@ -147,6 +147,14 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
     }
 }
 
+#[allow(clippy::from_over_into)]
+// We do not implement From<Vec<u8>> because bytes must be validated
+impl<const MIN: usize, const MAX: usize> Into<Vec<u8>> for OctetString<MIN, MAX> {
+    fn into(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
 impl<const MIN: usize, const MAX: usize> core::fmt::Debug for OctetString<MIN, MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OctetString")

--- a/rusmpp/src/values/callback_num_pres_ind.rs
+++ b/rusmpp/src/values/callback_num_pres_ind.rs
@@ -3,7 +3,7 @@ crate::create! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
     #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
     #[cfg_attr(feature = "serde", derive(::serde::Serialize))]
-#[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
+    #[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
     pub struct CallbackNumPresInd {
         pub presentation: Presentation,
         pub screening: Screening,

--- a/rusmpp/src/values/esm_class.rs
+++ b/rusmpp/src/values/esm_class.rs
@@ -4,7 +4,7 @@ crate::create! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
     #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
     #[cfg_attr(feature = "serde", derive(::serde::Serialize))]
-#[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
+    #[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
     pub struct EsmClass {
         pub messaging_mode: MessagingMode,
         pub message_type: MessageType,

--- a/rusmpp/src/values/mod.rs
+++ b/rusmpp/src/values/mod.rs
@@ -1,138 +1,154 @@
 //! `SMPP` values.
 
-// TODO: do the exporting of values and the exporting of parts. see pdus module for example.
+pub mod parts {
+    pub use super::broadcast_area_identifier::BroadcastAreaIdentifierParts;
+    pub use super::broadcast_content_type::BroadcastContentTypeParts;
+    pub use super::broadcast_frequency_interval::BroadcastFrequencyIntervalParts;
+    pub use super::broadcast_rep_num::BroadcastRepNumParts;
+    pub use super::dest_address::{DistributionListNameParts, SmeAddressParts};
+    pub use super::its_session_info::ItsSessionInfoParts;
+    pub use super::message_payload::MessagePayloadParts;
+    pub use super::ms_validity::{MsValidityInformationParts, MsValidityParts};
+    pub use super::network_error_code::NetworkErrorCodeParts;
+    pub use super::service_type::ServiceTypeParts;
+    pub use super::sub_address::SubaddressParts;
+    pub use super::unsuccess_sme::UnsuccessSmeParts;
+    pub use super::user_message_reference::UserMessageReferenceParts;
+}
 
 mod addr_subunit;
-pub use addr_subunit::*;
+pub use addr_subunit::AddrSubunit;
 
 mod alert_on_msg_delivery;
-pub use alert_on_msg_delivery::*;
+pub use alert_on_msg_delivery::AlertOnMessageDelivery;
 
 mod bearer_type;
-pub use bearer_type::*;
+pub use bearer_type::BearerType;
 
 mod broadcast_area_identifier;
-pub use broadcast_area_identifier::*;
+pub use broadcast_area_identifier::{BroadcastAreaFormat, BroadcastAreaIdentifier};
 
 mod broadcast_area_success;
-pub use broadcast_area_success::*;
+pub use broadcast_area_success::BroadcastAreaSuccess;
 
 mod broadcast_channel_indicator;
-pub use broadcast_channel_indicator::*;
+pub use broadcast_channel_indicator::BroadcastChannelIndicator;
 
 mod broadcast_content_type;
-pub use broadcast_content_type::*;
+pub use broadcast_content_type::{BroadcastContentType, EncodingContentType, TypeOfNetwork};
 
 mod broadcast_frequency_interval;
-pub use broadcast_frequency_interval::*;
+pub use broadcast_frequency_interval::{BroadcastFrequencyInterval, UnitOfTime};
 
 mod broadcast_message_class;
-pub use broadcast_message_class::*;
+pub use broadcast_message_class::BroadcastMessageClass;
 
 mod callback_num_pres_ind;
-pub use callback_num_pres_ind::*;
+pub use callback_num_pres_ind::{CallbackNumPresInd, Presentation, Screening};
 
 mod congestion_state;
-pub use congestion_state::*;
+pub use congestion_state::CongestionState;
 
 mod data_coding;
-pub use data_coding::*;
+pub use data_coding::DataCoding;
 
 mod delivery_failure_reason;
-pub use delivery_failure_reason::*;
+pub use delivery_failure_reason::DeliveryFailureReason;
 
 mod dest_addr_np_resolution;
-pub use dest_addr_np_resolution::*;
+pub use dest_addr_np_resolution::DestAddrNpResolution;
 
 mod dest_address;
-pub use dest_address::*;
+pub use dest_address::{DestAddress, DestFlag, DistributionListName, SmeAddress};
 
 mod display_time;
-pub use display_time::*;
+pub use display_time::DisplayTime;
 
 mod dpf_result;
-pub use dpf_result::*;
+pub use dpf_result::DpfResult;
 
 mod esm_class;
-pub use esm_class::*;
+pub use esm_class::{Ansi41Specific, EsmClass, GsmFeatures, MessageType, MessagingMode};
 
 mod interface_version;
-pub use interface_version::*;
+pub use interface_version::InterfaceVersion;
 
 mod its_reply_type;
-pub use its_reply_type::*;
+pub use its_reply_type::ItsReplyType;
 
 mod its_session_info;
-pub use its_session_info::*;
+pub use its_session_info::ItsSessionInfo;
 
 mod language_indicator;
-pub use language_indicator::*;
+pub use language_indicator::LanguageIndicator;
 
 mod message_state;
-pub use message_state::*;
+pub use message_state::MessageState;
 
 mod more_messages_to_send;
-pub use more_messages_to_send::*;
+pub use more_messages_to_send::MoreMessagesToSend;
 
 mod ms_availability_status;
-pub use ms_availability_status::*;
+pub use ms_availability_status::MsAvailabilityStatus;
 
 mod ms_msg_wait_facilities;
-pub use ms_msg_wait_facilities::*;
+pub use ms_msg_wait_facilities::{Indicator, MsMsgWaitFacilities, TypeOfMessage};
 
 mod ms_validity;
-pub use ms_validity::*;
+pub use ms_validity::{MsValidity, MsValidityBehavior, MsValidityInformation, UnitsOfTime};
 
 mod network_error_code;
-pub use network_error_code::*;
+pub use network_error_code::{ErrorCodeNetworkType, NetworkErrorCode};
 
 mod network_type;
-pub use network_type::*;
+pub use network_type::NetworkType;
 
 mod npi;
-pub use npi::*;
+pub use npi::Npi;
 
 mod number_of_messages;
-pub use number_of_messages::*;
+pub use number_of_messages::NumberOfMessages;
 
 mod payload_type;
-pub use payload_type::*;
+pub use payload_type::PayloadType;
 
 mod priority_flag;
-pub use priority_flag::*;
+pub use priority_flag::{Ansi41Cbs, Ansi136, GsmCbs, GsmSms, Is95, PriorityFlag, PriorityFlagType};
 
 mod privacy_indicator;
-pub use privacy_indicator::*;
+pub use privacy_indicator::PrivacyIndicator;
 
 mod registered_delivery;
-pub use registered_delivery::*;
+pub use registered_delivery::{
+    IntermediateNotification, MCDeliveryReceipt, RegisteredDelivery, SmeOriginatedAcknowledgement,
+};
 
 mod replace_if_present_flag;
-pub use replace_if_present_flag::*;
+pub use replace_if_present_flag::ReplaceIfPresentFlag;
 
 mod service_type;
-pub use service_type::*;
+pub use service_type::{GenericServiceType, ServiceType};
 
 mod set_dpf;
-pub use set_dpf::*;
+pub use set_dpf::SetDpf;
 
 mod sub_address;
-pub use sub_address::*;
+pub use sub_address::{Subaddress, SubaddressTag};
 
 mod ton;
-pub use ton::*;
+pub use ton::Ton;
 
 mod unsuccess_sme;
-pub use unsuccess_sme::*;
+pub use unsuccess_sme::UnsuccessSme;
 
 mod ussd_service_op;
-pub use ussd_service_op::*;
+pub use ussd_service_op::UssdServiceOp;
 
 mod user_message_reference;
-pub use user_message_reference::*;
+pub use user_message_reference::UserMessageReference;
 
 mod broadcast_rep_num;
-pub use broadcast_rep_num::*;
+pub use broadcast_rep_num::BroadcastRepNum;
 
 mod message_payload;
-pub use message_payload::*;
+pub use message_payload::MessagePayload;

--- a/rusmpp/src/values/mod.rs
+++ b/rusmpp/src/values/mod.rs
@@ -1,5 +1,7 @@
 //! `SMPP` values.
 
+// TODO: do the exporting of values and the exporting of parts. see pdus module for example.
+
 mod addr_subunit;
 pub use addr_subunit::*;
 

--- a/rusmpp/src/values/mod.rs
+++ b/rusmpp/src/values/mod.rs
@@ -5,11 +5,16 @@ pub mod parts {
     pub use super::broadcast_content_type::BroadcastContentTypeParts;
     pub use super::broadcast_frequency_interval::BroadcastFrequencyIntervalParts;
     pub use super::broadcast_rep_num::BroadcastRepNumParts;
+    pub use super::callback_num_pres_ind::CallbackNumPresIndParts;
     pub use super::dest_address::{DistributionListNameParts, SmeAddressParts};
+    pub use super::esm_class::EsmClassParts;
     pub use super::its_session_info::ItsSessionInfoParts;
     pub use super::message_payload::MessagePayloadParts;
+    pub use super::ms_msg_wait_facilities::MsMsgWaitFacilitiesParts;
     pub use super::ms_validity::{MsValidityInformationParts, MsValidityParts};
     pub use super::network_error_code::NetworkErrorCodeParts;
+    pub use super::priority_flag::PriorityFlagParts;
+    pub use super::registered_delivery::RegisteredDeliveryParts;
     pub use super::service_type::ServiceTypeParts;
     pub use super::sub_address::SubaddressParts;
     pub use super::unsuccess_sme::UnsuccessSmeParts;

--- a/rusmpp/src/values/ms_msg_wait_facilities.rs
+++ b/rusmpp/src/values/ms_msg_wait_facilities.rs
@@ -3,7 +3,7 @@ crate::create! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
     #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
     #[cfg_attr(feature = "serde", derive(::serde::Serialize))]
-#[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
+    #[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
     pub struct MsMsgWaitFacilities {
         pub indicator: Indicator,
         pub type_of_message: TypeOfMessage,

--- a/rusmpp/src/values/registered_delivery.rs
+++ b/rusmpp/src/values/registered_delivery.rs
@@ -3,7 +3,7 @@ crate::create! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
     #[cfg_attr(feature = "arbitrary", derive(::arbitrary::Arbitrary))]
     #[cfg_attr(feature = "serde", derive(::serde::Serialize))]
-#[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
+    #[cfg_attr(feature = "serde-deserialize-unchecked", derive(::serde::Deserialize))]
     pub struct RegisteredDelivery {
         mc_delivery_receipt: MCDeliveryReceipt,
         sme_originated_acknowledgement: SmeOriginatedAcknowledgement,

--- a/rusmpp/tests/expand/struct.expanded.rs
+++ b/rusmpp/tests/expand/struct.expanded.rs
@@ -25,6 +25,57 @@ impl ::core::fmt::Debug for CancelSm {
         )
     }
 }
+pub struct CancelSmParts {
+    pub service_type: ServiceType,
+    pub message_id: COctetString<1, 65>,
+    pub other: u8,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for CancelSmParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(
+            f,
+            "CancelSmParts",
+            "service_type",
+            &self.service_type,
+            "message_id",
+            &self.message_id,
+            "other",
+            &&self.other,
+        )
+    }
+}
+impl CancelSmParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        service_type: ServiceType,
+        message_id: COctetString<1, 65>,
+        other: u8,
+    ) -> Self {
+        Self {
+            service_type,
+            message_id,
+            other,
+        }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (ServiceType, COctetString<1, 65>, u8) {
+        (self.service_type, self.message_id, self.other)
+    }
+}
+impl CancelSm {
+    #[inline]
+    pub fn into_parts(self) -> CancelSmParts {
+        CancelSmParts {
+            service_type: self.service_type,
+            message_id: self.message_id,
+            other: self.other,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for CancelSm {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_count_ident.expanded.rs
+++ b/rusmpp/tests/expand/struct_count_ident.expanded.rs
@@ -28,6 +28,57 @@ impl ::core::fmt::Debug for SubmitMulti {
         )
     }
 }
+pub struct SubmitMultiParts {
+    pub other: u8,
+    pub number_of_dests: u8,
+    pub dest_address: ::alloc::vec::Vec<DestAddress>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for SubmitMultiParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(
+            f,
+            "SubmitMultiParts",
+            "other",
+            &self.other,
+            "number_of_dests",
+            &self.number_of_dests,
+            "dest_address",
+            &&self.dest_address,
+        )
+    }
+}
+impl SubmitMultiParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        other: u8,
+        number_of_dests: u8,
+        dest_address: ::alloc::vec::Vec<DestAddress>,
+    ) -> Self {
+        Self {
+            other,
+            number_of_dests,
+            dest_address,
+        }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (u8, u8, ::alloc::vec::Vec<DestAddress>) {
+        (self.other, self.number_of_dests, self.dest_address)
+    }
+}
+impl SubmitMulti {
+    #[inline]
+    pub fn into_parts(self) -> SubmitMultiParts {
+        SubmitMultiParts {
+            other: self.other,
+            number_of_dests: self.number_of_dests,
+            dest_address: self.dest_address,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for SubmitMulti {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_key_length_ident.expanded.rs
+++ b/rusmpp/tests/expand/struct_key_length_ident.expanded.rs
@@ -28,6 +28,49 @@ impl ::core::fmt::Debug for Tlv {
         )
     }
 }
+pub struct TlvParts {
+    pub tag: TlvTag,
+    pub value_length: u16,
+    pub value: Option<TlvValue>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for TlvParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(
+            f,
+            "TlvParts",
+            "tag",
+            &self.tag,
+            "value_length",
+            &self.value_length,
+            "value",
+            &&self.value,
+        )
+    }
+}
+impl TlvParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(tag: TlvTag, value_length: u16, value: Option<TlvValue>) -> Self {
+        Self { tag, value_length, value }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (TlvTag, u16, Option<TlvValue>) {
+        (self.tag, self.value_length, self.value)
+    }
+}
+impl Tlv {
+    #[inline]
+    pub fn into_parts(self) -> TlvParts {
+        TlvParts {
+            tag: self.tag,
+            value_length: self.value_length,
+            value: self.value,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for Tlv {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_key_length_unchecked.expanded.rs
+++ b/rusmpp/tests/expand/struct_key_length_unchecked.expanded.rs
@@ -31,6 +31,63 @@ impl ::core::fmt::Debug for Command {
         )
     }
 }
+pub struct CommandParts {
+    pub command_id: CommandId,
+    pub command_status: CommandStatus,
+    pub sequence_number: u32,
+    pub pdu: Option<Pdu>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for CommandParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field4_finish(
+            f,
+            "CommandParts",
+            "command_id",
+            &self.command_id,
+            "command_status",
+            &self.command_status,
+            "sequence_number",
+            &self.sequence_number,
+            "pdu",
+            &&self.pdu,
+        )
+    }
+}
+impl CommandParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        command_id: CommandId,
+        command_status: CommandStatus,
+        sequence_number: u32,
+        pdu: Option<Pdu>,
+    ) -> Self {
+        Self {
+            command_id,
+            command_status,
+            sequence_number,
+            pdu,
+        }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (CommandId, CommandStatus, u32, Option<Pdu>) {
+        (self.command_id, self.command_status, self.sequence_number, self.pdu)
+    }
+}
+impl Command {
+    #[inline]
+    pub fn into_parts(self) -> CommandParts {
+        CommandParts {
+            command_id: self.command_id,
+            command_status: self.command_status,
+            sequence_number: self.sequence_number,
+            pdu: self.pdu,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for Command {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_length_checked.expanded.rs
+++ b/rusmpp/tests/expand/struct_length_checked.expanded.rs
@@ -25,6 +25,51 @@ impl ::core::fmt::Debug for MsValidity {
         )
     }
 }
+pub struct MsValidityParts {
+    pub validity_behavior: MsValidityBehavior,
+    pub validity_information: Option<MsValidityInformation>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for MsValidityParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "MsValidityParts",
+            "validity_behavior",
+            &self.validity_behavior,
+            "validity_information",
+            &&self.validity_information,
+        )
+    }
+}
+impl MsValidityParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        validity_behavior: MsValidityBehavior,
+        validity_information: Option<MsValidityInformation>,
+    ) -> Self {
+        Self {
+            validity_behavior,
+            validity_information,
+        }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (MsValidityBehavior, Option<MsValidityInformation>) {
+        (self.validity_behavior, self.validity_information)
+    }
+}
+impl MsValidity {
+    #[inline]
+    pub fn into_parts(self) -> MsValidityParts {
+        MsValidityParts {
+            validity_behavior: self.validity_behavior,
+            validity_information: self.validity_information,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for MsValidity {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_length_ident.expanded.rs
+++ b/rusmpp/tests/expand/struct_length_ident.expanded.rs
@@ -28,6 +28,57 @@ impl ::core::fmt::Debug for SubmitSm {
         )
     }
 }
+pub struct SubmitSmParts {
+    pub other: u8,
+    pub sm_length: u8,
+    pub short_message: OctetString<0, 255>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for SubmitSmParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field3_finish(
+            f,
+            "SubmitSmParts",
+            "other",
+            &self.other,
+            "sm_length",
+            &self.sm_length,
+            "short_message",
+            &&self.short_message,
+        )
+    }
+}
+impl SubmitSmParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        other: u8,
+        sm_length: u8,
+        short_message: OctetString<0, 255>,
+    ) -> Self {
+        Self {
+            other,
+            sm_length,
+            short_message,
+        }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (u8, u8, OctetString<0, 255>) {
+        (self.other, self.sm_length, self.short_message)
+    }
+}
+impl SubmitSm {
+    #[inline]
+    pub fn into_parts(self) -> SubmitSmParts {
+        SubmitSmParts {
+            other: self.other,
+            sm_length: self.sm_length,
+            short_message: self.short_message,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for SubmitSm {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_length_unchecked.expanded.rs
+++ b/rusmpp/tests/expand/struct_length_unchecked.expanded.rs
@@ -25,6 +25,45 @@ impl ::core::fmt::Debug for BroadcastAreaIdentifier {
         )
     }
 }
+pub struct BroadcastAreaIdentifierParts {
+    pub format: BroadcastAreaFormat,
+    pub area: OctetString<0, 100>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for BroadcastAreaIdentifierParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "BroadcastAreaIdentifierParts",
+            "format",
+            &self.format,
+            "area",
+            &&self.area,
+        )
+    }
+}
+impl BroadcastAreaIdentifierParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(format: BroadcastAreaFormat, area: OctetString<0, 100>) -> Self {
+        Self { format, area }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (BroadcastAreaFormat, OctetString<0, 100>) {
+        (self.format, self.area)
+    }
+}
+impl BroadcastAreaIdentifier {
+    #[inline]
+    pub fn into_parts(self) -> BroadcastAreaIdentifierParts {
+        BroadcastAreaIdentifierParts {
+            format: self.format,
+            area: self.area,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for BroadcastAreaIdentifier {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_repr.expanded.rs
+++ b/rusmpp/tests/expand/struct_repr.expanded.rs
@@ -22,6 +22,45 @@ impl ::core::fmt::Debug for CallbackNumPresInd {
         )
     }
 }
+pub struct CallbackNumPresIndParts {
+    pub presentation: Presentation,
+    pub screening: Screening,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for CallbackNumPresIndParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "CallbackNumPresIndParts",
+            "presentation",
+            &self.presentation,
+            "screening",
+            &&self.screening,
+        )
+    }
+}
+impl CallbackNumPresIndParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(presentation: Presentation, screening: Screening) -> Self {
+        Self { presentation, screening }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (Presentation, Screening) {
+        (self.presentation, self.screening)
+    }
+}
+impl CallbackNumPresInd {
+    #[inline]
+    pub fn into_parts(self) -> CallbackNumPresIndParts {
+        CallbackNumPresIndParts {
+            presentation: self.presentation,
+            screening: self.screening,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for CallbackNumPresInd {
     fn length(&self) -> usize {
         u8::from(*self).length()

--- a/rusmpp/tests/expand/struct_skip.expanded.rs
+++ b/rusmpp/tests/expand/struct_skip.expanded.rs
@@ -22,6 +22,45 @@ impl ::core::fmt::Debug for DistributionListName {
         )
     }
 }
+pub struct DistributionListNameParts {
+    pub dest_flag: DestFlag,
+    pub dl_name: COctetString<1, 21>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for DistributionListNameParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "DistributionListNameParts",
+            "dest_flag",
+            &self.dest_flag,
+            "dl_name",
+            &&self.dl_name,
+        )
+    }
+}
+impl DistributionListNameParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(dest_flag: DestFlag, dl_name: COctetString<1, 21>) -> Self {
+        Self { dest_flag, dl_name }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (DestFlag, COctetString<1, 21>) {
+        (self.dest_flag, self.dl_name)
+    }
+}
+impl DistributionListName {
+    #[inline]
+    pub fn into_parts(self) -> DistributionListNameParts {
+        DistributionListNameParts {
+            dest_flag: self.dest_flag,
+            dl_name: self.dl_name,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for DistributionListName {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_skip_field.expanded.rs
+++ b/rusmpp/tests/expand/struct_skip_field.expanded.rs
@@ -22,6 +22,45 @@ impl ::core::fmt::Debug for DistributionListName {
         )
     }
 }
+pub struct DistributionListNameParts {
+    pub dest_flag: DestFlag,
+    pub dl_name: COctetString<1, 21>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for DistributionListNameParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "DistributionListNameParts",
+            "dest_flag",
+            &self.dest_flag,
+            "dl_name",
+            &&self.dl_name,
+        )
+    }
+}
+impl DistributionListNameParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(dest_flag: DestFlag, dl_name: COctetString<1, 21>) -> Self {
+        Self { dest_flag, dl_name }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (DestFlag, COctetString<1, 21>) {
+        (self.dest_flag, self.dl_name)
+    }
+}
+impl DistributionListName {
+    #[inline]
+    pub fn into_parts(self) -> DistributionListNameParts {
+        DistributionListNameParts {
+            dest_flag: self.dest_flag,
+            dl_name: self.dl_name,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for DistributionListName {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpp/tests/expand/struct_skip_test.expanded.rs
+++ b/rusmpp/tests/expand/struct_skip_test.expanded.rs
@@ -22,6 +22,45 @@ impl ::core::fmt::Debug for DistributionListName {
         )
     }
 }
+pub struct DistributionListNameParts {
+    pub dest_flag: DestFlag,
+    pub dl_name: COctetString<1, 21>,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for DistributionListNameParts {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field2_finish(
+            f,
+            "DistributionListNameParts",
+            "dest_flag",
+            &self.dest_flag,
+            "dl_name",
+            &&self.dl_name,
+        )
+    }
+}
+impl DistributionListNameParts {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(dest_flag: DestFlag, dl_name: COctetString<1, 21>) -> Self {
+        Self { dest_flag, dl_name }
+    }
+    #[inline]
+    #[allow(unused_parens)]
+    pub fn raw(self) -> (DestFlag, COctetString<1, 21>) {
+        (self.dest_flag, self.dl_name)
+    }
+}
+impl DistributionListName {
+    #[inline]
+    pub fn into_parts(self) -> DistributionListNameParts {
+        DistributionListNameParts {
+            dest_flag: self.dest_flag,
+            dl_name: self.dl_name,
+        }
+    }
+}
 impl ::rusmpp::encode::Length for DistributionListName {
     fn length(&self) -> usize {
         let mut length = 0;

--- a/rusmpps/src/connection.rs
+++ b/rusmpps/src/connection.rs
@@ -77,7 +77,7 @@ impl Connection {
                         tracing::debug!(session_id, id=?command.id(), "Received bind command");
                         tracing::trace!(session_id, ?command, "Received bind command");
 
-                        let (_, status, sequence_number, pdu) = command.into_parts();
+                        let (_, status, sequence_number, pdu) = command.into_parts().raw();
 
                         if !(matches!(status, CommandStatus::EsmeRok)) {
                             // Really?
@@ -242,7 +242,7 @@ impl Connection {
                     tracing::debug!(session_id, sequence_number, id=?command.id(), "Received command");
                     tracing::trace!(session_id, sequence_number, ?command, "Received command");
 
-                    let (id, _, sequence_number, pdu) = command.into_parts();
+                    let (id, _, sequence_number, pdu) = command.into_parts().raw();
 
                     let pdu: Pdu = match pdu {
                         Some(Pdu::Unbind) => {


### PR DESCRIPTION
Added `into_parts` for all types. 

`Breaking`: `Command::into_parts` returned a tuple of parts, now it returns `CommandParts` instead.
`Migrating`: use `Command::into_parts::raw` for the same result (tuple of parts).