### PR TITLE
feat(rusmpp-core/pdus)!: replaced params Vec<impl Into<T>> with Vec<T>

### DIFF
--- a/rusmpp-core/src/pdus/borrowed/broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/broadcast_sm.rs
@@ -100,9 +100,9 @@ impl<'a, const N: usize> BroadcastSm<'a, N> {
         replace_if_present_flag: ReplaceIfPresentFlag,
         data_coding: DataCoding,
         sm_default_msg_id: u8,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<BroadcastRequestTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -124,11 +124,8 @@ impl<'a, const N: usize> BroadcastSm<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastRequestTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<BroadcastRequestTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -225,10 +222,7 @@ impl<'a, const N: usize> BroadcastSmBuilder<'a, N> {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastRequestTlvValue<'a>>, N>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: heapless::vec::Vec<BroadcastRequestTlvValue<'a>, N>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/broadcast_sm_resp.rs
@@ -24,9 +24,9 @@ pub struct BroadcastSmResp<'a, const N: usize> {
 impl<'a, const N: usize> BroadcastSmResp<'a, N> {
     pub fn new(
         message_id: COctetString<'a, 1, 65>,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<BroadcastResponseTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -35,11 +35,8 @@ impl<'a, const N: usize> BroadcastSmResp<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastResponseTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<BroadcastResponseTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -80,10 +77,7 @@ impl<'a, const N: usize> BroadcastSmRespBuilder<'a, N> {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: heapless::vec::Vec<impl Into<BroadcastResponseTlvValue<'a>>, N>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: heapless::vec::Vec<BroadcastResponseTlvValue<'a>, N>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/cancel_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/cancel_broadcast_sm.rs
@@ -73,9 +73,9 @@ impl<'a, const N: usize> CancelBroadcastSm<'a, N> {
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<'a, 1, 21>,
-        tlvs: heapless::vec::Vec<impl Into<CancelBroadcastTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<CancelBroadcastTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -91,11 +91,8 @@ impl<'a, const N: usize> CancelBroadcastSm<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<CancelBroadcastTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<CancelBroadcastTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -153,10 +150,7 @@ impl<'a, const N: usize> CancelBroadcastSmBuilder<'a, N> {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: heapless::vec::Vec<impl Into<CancelBroadcastTlvValue<'a>>, N>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: heapless::vec::Vec<CancelBroadcastTlvValue<'a>, N>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/data_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/data_sm.rs
@@ -80,9 +80,9 @@ impl<'a, const N: usize> DataSm<'a, N> {
         esm_class: EsmClass,
         registered_delivery: RegisteredDelivery,
         data_coding: DataCoding,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -103,11 +103,8 @@ impl<'a, const N: usize> DataSm<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -195,7 +192,7 @@ impl<'a, const N: usize> DataSmBuilder<'a, N> {
 
     pub fn tlvs(
         mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
         self.inner.set_tlvs(tlvs);
         self

--- a/rusmpp-core/src/pdus/borrowed/deliver_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/deliver_sm.rs
@@ -108,9 +108,9 @@ impl<'a, const N: usize> DeliverSm<'a, N> {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<'a, 0, 255>,
-        tlvs: heapless::vec::Vec<impl Into<MessageDeliveryRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageDeliveryRequestTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         let sm_length = short_message.length() as u8;
 
@@ -160,11 +160,8 @@ impl<'a, const N: usize> DeliverSm<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageDeliveryRequestTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageDeliveryRequestTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -291,10 +288,7 @@ impl<'a, const N: usize> DeliverSmBuilder<'a, N> {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageDeliveryRequestTlvValue<'a>>, N>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: heapless::vec::Vec<MessageDeliveryRequestTlvValue<'a>, N>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/query_broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/query_broadcast_sm_resp.rs
@@ -25,9 +25,9 @@ pub struct QueryBroadcastSmResp<'a, const N: usize> {
 impl<'a, const N: usize> QueryBroadcastSmResp<'a, N> {
     pub fn new(
         message_id: COctetString<'a, 1, 65>,
-        tlvs: heapless::vec::Vec<impl Into<QueryBroadcastResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<QueryBroadcastResponseTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -36,11 +36,8 @@ impl<'a, const N: usize> QueryBroadcastSmResp<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<QueryBroadcastResponseTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<QueryBroadcastResponseTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -81,10 +78,7 @@ impl<'a, const N: usize> QueryBroadcastSmRespBuilder<'a, N> {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: heapless::vec::Vec<impl Into<QueryBroadcastResponseTlvValue<'a>>, N>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: heapless::vec::Vec<QueryBroadcastResponseTlvValue<'a>, N>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/sm_resp.rs
@@ -27,9 +27,9 @@ macro_rules! sm_resp {
         impl<'a, const N: usize> $name<'a, N> {
             pub fn new(
                 message_id: COctetString<'a, 1, 65>,
-                tlvs: heapless::vec::Vec<impl Into<MessageDeliveryResponseTlvValue<'a>>, N>,
+                tlvs: heapless::vec::Vec<MessageDeliveryResponseTlvValue<'a>, N>,
             ) -> Self {
-                let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+                let tlvs = tlvs.into_iter().map(From::from).collect();
 
                 Self { message_id, tlvs }
             }
@@ -44,9 +44,9 @@ macro_rules! sm_resp {
 
             pub fn set_tlvs(
                 &mut self,
-                tlvs: heapless::vec::Vec<impl Into<MessageDeliveryResponseTlvValue<'a>>, N>,
+                tlvs: heapless::vec::Vec<MessageDeliveryResponseTlvValue<'a>, N>,
             ) {
-                self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+                self.tlvs = tlvs.into_iter().map(From::from).collect();
             }
 
             pub fn push_tlv(&mut self, tlv: impl Into<MessageDeliveryResponseTlvValue<'a>>) -> Result<(), Tlv<'a>> {
@@ -79,7 +79,7 @@ macro_rules! sm_resp {
 
                 pub fn tlvs(
                     mut self,
-                    tlvs: heapless::vec::Vec<impl Into<MessageDeliveryResponseTlvValue<'a>>, N>,
+                    tlvs: heapless::vec::Vec<MessageDeliveryResponseTlvValue<'a>, N>,
                 ) -> Self {
                     self.inner.set_tlvs(tlvs);
                     self

--- a/rusmpp-core/src/pdus/borrowed/submit_multi.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_multi.rs
@@ -116,12 +116,12 @@ impl<'a, const N: usize> SubmitMulti<'a, N> {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<'a, 0, 255>,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
         let sm_length = short_message.length() as u8;
         let number_of_dests = dest_address.len() as u8;
 
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -196,11 +196,8 @@ impl<'a, const N: usize> SubmitMulti<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -332,7 +329,7 @@ impl<'a, const N: usize> SubmitMultiBuilder<'a, N> {
 
     pub fn tlvs(
         mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
         self.inner.set_tlvs(tlvs);
         self

--- a/rusmpp-core/src/pdus/borrowed/submit_multi_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_multi_resp.rs
@@ -37,11 +37,11 @@ impl<'a, const N: usize> SubmitMultiResp<'a, N> {
     pub fn new(
         message_id: COctetString<'a, 1, 65>,
         unsuccess_sme: heapless::vec::Vec<UnsuccessSme<'a>, N>,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>,
     ) -> Self {
         let no_unsuccess = unsuccess_sme.len() as u8;
 
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             message_id,
@@ -82,11 +82,8 @@ impl<'a, const N: usize> SubmitMultiResp<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -147,7 +144,7 @@ impl<'a, const N: usize> SubmitMultiRespBuilder<'a, N> {
 
     pub fn tlvs(
         mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>,
     ) -> Self {
         self.inner.set_tlvs(tlvs);
         self

--- a/rusmpp-core/src/pdus/borrowed/submit_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_sm.rs
@@ -106,9 +106,9 @@ impl<'a, const N: usize> SubmitSm<'a, N> {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<'a, 0, 255>,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         let sm_length = short_message.length() as u8;
 
@@ -158,11 +158,8 @@ impl<'a, const N: usize> SubmitSm<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -291,7 +288,7 @@ impl<'a, const N: usize> SubmitSmBuilder<'a, N> {
 
     pub fn tlvs(
         mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionRequestTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionRequestTlvValue<'a>, N>,
     ) -> Self {
         self.inner.set_tlvs(tlvs);
         self

--- a/rusmpp-core/src/pdus/borrowed/submit_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_sm_resp.rs
@@ -24,9 +24,9 @@ pub struct SubmitSmResp<'a, const N: usize> {
 impl<'a, const N: usize> SubmitSmResp<'a, N> {
     pub fn new(
         message_id: COctetString<'a, 1, 65>,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -39,11 +39,8 @@ impl<'a, const N: usize> SubmitSmResp<'a, N> {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -86,7 +83,7 @@ impl<'a, const N: usize> SubmitSmRespBuilder<'a, N> {
 
     pub fn tlvs(
         mut self,
-        tlvs: heapless::vec::Vec<impl Into<MessageSubmissionResponseTlvValue<'a>>, N>,
+        tlvs: heapless::vec::Vec<MessageSubmissionResponseTlvValue<'a>, N>,
     ) -> Self {
         self.inner.set_tlvs(tlvs);
         self

--- a/rusmpp-core/src/pdus/owned/broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/owned/broadcast_sm.rs
@@ -100,9 +100,9 @@ impl BroadcastSm {
         replace_if_present_flag: ReplaceIfPresentFlag,
         data_coding: DataCoding,
         sm_default_msg_id: u8,
-        tlvs: alloc::vec::Vec<impl Into<BroadcastRequestTlvValue>>,
+        tlvs: alloc::vec::Vec<BroadcastRequestTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -124,8 +124,8 @@ impl BroadcastSm {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<BroadcastRequestTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<BroadcastRequestTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -218,7 +218,7 @@ impl BroadcastSmBuilder {
         self
     }
 
-    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<impl Into<BroadcastRequestTlvValue>>) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<BroadcastRequestTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/broadcast_sm_resp.rs
@@ -24,9 +24,9 @@ pub struct BroadcastSmResp {
 impl BroadcastSmResp {
     pub fn new(
         message_id: COctetString<1, 65>,
-        tlvs: alloc::vec::Vec<impl Into<BroadcastResponseTlvValue>>,
+        tlvs: alloc::vec::Vec<BroadcastResponseTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -35,8 +35,8 @@ impl BroadcastSmResp {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<BroadcastResponseTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<BroadcastResponseTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -73,7 +73,7 @@ impl BroadcastSmRespBuilder {
         self
     }
 
-    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<impl Into<BroadcastResponseTlvValue>>) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<BroadcastResponseTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/cancel_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/owned/cancel_broadcast_sm.rs
@@ -72,9 +72,9 @@ impl CancelBroadcastSm {
         source_addr_ton: Ton,
         source_addr_npi: Npi,
         source_addr: COctetString<1, 21>,
-        tlvs: alloc::vec::Vec<impl Into<CancelBroadcastTlvValue>>,
+        tlvs: alloc::vec::Vec<CancelBroadcastTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -90,8 +90,8 @@ impl CancelBroadcastSm {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<CancelBroadcastTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<CancelBroadcastTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -148,7 +148,7 @@ impl CancelBroadcastSmBuilder {
         self
     }
 
-    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<impl Into<CancelBroadcastTlvValue>>) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<CancelBroadcastTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/data_sm.rs
+++ b/rusmpp-core/src/pdus/owned/data_sm.rs
@@ -79,9 +79,9 @@ impl DataSm {
         esm_class: EsmClass,
         registered_delivery: RegisteredDelivery,
         data_coding: DataCoding,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -102,8 +102,8 @@ impl DataSm {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -185,10 +185,7 @@ impl DataSmBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/deliver_sm.rs
+++ b/rusmpp-core/src/pdus/owned/deliver_sm.rs
@@ -108,9 +108,9 @@ impl DeliverSm {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<0, 255>,
-        tlvs: alloc::vec::Vec<impl Into<MessageDeliveryRequestTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageDeliveryRequestTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         let sm_length = short_message.length() as u8;
 
@@ -160,8 +160,8 @@ impl DeliverSm {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<MessageDeliveryRequestTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageDeliveryRequestTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -284,10 +284,7 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageDeliveryRequestTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageDeliveryRequestTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/query_broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/query_broadcast_sm_resp.rs
@@ -25,9 +25,9 @@ pub struct QueryBroadcastSmResp {
 impl QueryBroadcastSmResp {
     pub fn new(
         message_id: COctetString<1, 65>,
-        tlvs: alloc::vec::Vec<impl Into<QueryBroadcastResponseTlvValue>>,
+        tlvs: alloc::vec::Vec<QueryBroadcastResponseTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -36,8 +36,8 @@ impl QueryBroadcastSmResp {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<QueryBroadcastResponseTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<QueryBroadcastResponseTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -74,10 +74,7 @@ impl QueryBroadcastSmRespBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<QueryBroadcastResponseTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<QueryBroadcastResponseTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/sm_resp.rs
@@ -26,9 +26,9 @@ macro_rules! sm_resp {
         impl $name {
             pub fn new(
                 message_id: COctetString<1, 65>,
-                tlvs: alloc::vec::Vec<impl Into<MessageDeliveryResponseTlvValue>>,
+                tlvs: alloc::vec::Vec<MessageDeliveryResponseTlvValue>,
             ) -> Self {
-                let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+                let tlvs = tlvs.into_iter().map(From::from).collect();
 
                 Self { message_id, tlvs }
             }
@@ -41,11 +41,8 @@ macro_rules! sm_resp {
                 &self.tlvs
             }
 
-            pub fn set_tlvs(
-                &mut self,
-                tlvs: alloc::vec::Vec<impl Into<MessageDeliveryResponseTlvValue>>,
-            ) {
-                self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+            pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageDeliveryResponseTlvValue>) {
+                self.tlvs = tlvs.into_iter().map(From::from).collect();
             }
 
             pub fn push_tlv(&mut self, tlv: impl Into<MessageDeliveryResponseTlvValue>) {
@@ -77,7 +74,7 @@ macro_rules! sm_resp {
 
                 pub fn tlvs(
                     mut self,
-                    tlvs: alloc::vec::Vec<impl Into<MessageDeliveryResponseTlvValue>>,
+                    tlvs: alloc::vec::Vec<MessageDeliveryResponseTlvValue>,
                 ) -> Self {
                     self.inner.set_tlvs(tlvs);
                     self

--- a/rusmpp-core/src/pdus/owned/submit_multi.rs
+++ b/rusmpp-core/src/pdus/owned/submit_multi.rs
@@ -115,12 +115,12 @@ impl SubmitMulti {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<0, 255>,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>,
     ) -> Self {
         let sm_length = short_message.length() as u8;
         let number_of_dests = dest_address.len() as u8;
 
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             service_type,
@@ -190,8 +190,8 @@ impl SubmitMulti {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -314,10 +314,7 @@ impl SubmitMultiBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/submit_multi_resp.rs
+++ b/rusmpp-core/src/pdus/owned/submit_multi_resp.rs
@@ -36,11 +36,11 @@ impl SubmitMultiResp {
     pub fn new(
         message_id: COctetString<1, 65>,
         unsuccess_sme: alloc::vec::Vec<UnsuccessSme>,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>,
     ) -> Self {
         let no_unsuccess = unsuccess_sme.len() as u8;
 
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self {
             message_id,
@@ -77,11 +77,8 @@ impl SubmitMultiResp {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -133,10 +130,7 @@ impl SubmitMultiRespBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/submit_sm.rs
+++ b/rusmpp-core/src/pdus/owned/submit_sm.rs
@@ -132,9 +132,9 @@ impl SubmitSm {
         data_coding: DataCoding,
         sm_default_msg_id: u8,
         short_message: OctetString<0, 255>,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         let sm_length = short_message.length() as u8;
 
@@ -184,8 +184,8 @@ impl SubmitSm {
         &self.tlvs
     }
 
-    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -328,10 +328,7 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionRequestTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageSubmissionRequestTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }

--- a/rusmpp-core/src/pdus/owned/submit_sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/submit_sm_resp.rs
@@ -24,9 +24,9 @@ pub struct SubmitSmResp {
 impl SubmitSmResp {
     pub fn new(
         message_id: COctetString<1, 65>,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
+        tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>,
     ) -> Self {
-        let tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+        let tlvs = tlvs.into_iter().map(From::from).collect();
 
         Self { message_id, tlvs }
     }
@@ -39,11 +39,8 @@ impl SubmitSmResp {
         &self.tlvs
     }
 
-    pub fn set_tlvs(
-        &mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
-    ) {
-        self.tlvs = tlvs.into_iter().map(Into::into).map(From::from).collect();
+    pub fn set_tlvs(&mut self, tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>) {
+        self.tlvs = tlvs.into_iter().map(From::from).collect();
     }
 
     pub fn clear_tlvs(&mut self) {
@@ -80,10 +77,7 @@ impl SubmitSmRespBuilder {
         self
     }
 
-    pub fn tlvs(
-        mut self,
-        tlvs: alloc::vec::Vec<impl Into<MessageSubmissionResponseTlvValue>>,
-    ) -> Self {
+    pub fn tlvs(mut self, tlvs: alloc::vec::Vec<MessageSubmissionResponseTlvValue>) -> Self {
         self.inner.set_tlvs(tlvs);
         self
     }


### PR DESCRIPTION
A `Vec<impl Into<T>>` is useless because all the elements in the vec must have the same type