### PR TITLE
ci: pin windows-2022 until aws-lc-rs releases a windows-latest compatible version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # Pin the windows-2022 version until aws-lc-rs supports windows-latest
+          - windows-2022
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Summary

- Pin windows-2022 os in `build-and-test` for Tests job