### PR TITLE
feat(rumspp-core): make every function const where possible

### DIFF
--- a/rusmpp-core/src/lib.rs
+++ b/rusmpp-core/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_debug_implementations)]
-
+#![deny(clippy::missing_const_for_fn)]
 //! ## Features
 //!
 //! - `alloc`:  Enables the `alloc` crate.

--- a/rusmpp-core/src/pdus/borrowed/alert_notification.rs
+++ b/rusmpp-core/src/pdus/borrowed/alert_notification.rs
@@ -106,32 +106,32 @@ impl<'a> AlertNotificationBuilder<'a> {
         Default::default()
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 65>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 65>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn esme_addr_ton(mut self, esme_addr_ton: Ton) -> Self {
+    pub const fn esme_addr_ton(mut self, esme_addr_ton: Ton) -> Self {
         self.inner.esme_addr_ton = esme_addr_ton;
         self
     }
 
-    pub fn esme_addr_npi(mut self, esme_addr_npi: Npi) -> Self {
+    pub const fn esme_addr_npi(mut self, esme_addr_npi: Npi) -> Self {
         self.inner.esme_addr_npi = esme_addr_npi;
         self
     }
 
-    pub fn esme_addr(mut self, esme_addr: COctetString<'a, 1, 65>) -> Self {
+    pub const fn esme_addr(mut self, esme_addr: COctetString<'a, 1, 65>) -> Self {
         self.inner.esme_addr = esme_addr;
         self
     }
@@ -145,7 +145,7 @@ impl<'a> AlertNotificationBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> AlertNotification<'a> {
+    pub const fn build(self) -> AlertNotification<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/bind.rs
+++ b/rusmpp-core/src/pdus/borrowed/bind.rs
@@ -83,17 +83,17 @@ macro_rules! bind {
                     Self::default()
                 }
 
-                pub fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
+                pub const fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
                     self.inner.system_id = system_id;
                     self
                 }
 
-                pub fn password(mut self, password: COctetString<'a, 1, 9>) -> Self {
+                pub const fn password(mut self, password: COctetString<'a, 1, 9>) -> Self {
                     self.inner.password = password;
                     self
                 }
 
-                pub fn system_type(mut self, system_type: COctetString<'a, 1, 13>) -> Self {
+                pub const fn system_type(mut self, system_type: COctetString<'a, 1, 13>) -> Self {
                     self.inner.system_type = system_type;
                     self
                 }
@@ -113,12 +113,12 @@ macro_rules! bind {
                     self
                 }
 
-                pub fn address_range(mut self, address_range: COctetString<'a, 1, 41>) -> Self {
+                pub const fn address_range(mut self, address_range: COctetString<'a, 1, 41>) -> Self {
                     self.inner.address_range = address_range;
                     self
                 }
 
-                pub fn build(self) -> $name<'a> {
+                pub const fn build(self) -> $name<'a> {
                     self.inner
                 }
             }

--- a/rusmpp-core/src/pdus/borrowed/bind_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/bind_resp.rs
@@ -77,7 +77,7 @@ macro_rules! bind_resp {
                     Self::default()
                 }
 
-                pub fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
+                pub const fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
                     self.inner.system_id = system_id;
                     self
                 }
@@ -90,7 +90,7 @@ macro_rules! bind_resp {
                     self
                 }
 
-                pub fn build(self) -> $name<'a> {
+                pub const fn build(self) -> $name<'a> {
                     self.inner
                 }
             }

--- a/rusmpp-core/src/pdus/borrowed/broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/broadcast_sm.rs
@@ -161,37 +161,37 @@ impl<'a, const N: usize> BroadcastSmBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
 
-    pub fn schedule_delivery_time(
+    pub const fn schedule_delivery_time(
         mut self,
         schedule_delivery_time: EmptyOrFullCOctetString<'a, 17>,
     ) -> Self {
@@ -199,12 +199,15 @@ impl<'a, const N: usize> BroadcastSmBuilder<'a, N> {
         self
     }
 
-    pub fn validity_period(mut self, validity_period: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn validity_period(
+        mut self,
+        validity_period: EmptyOrFullCOctetString<'a, 17>,
+    ) -> Self {
         self.inner.validity_period = validity_period;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -212,12 +215,12 @@ impl<'a, const N: usize> BroadcastSmBuilder<'a, N> {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/broadcast_sm_resp.rs
@@ -72,7 +72,7 @@ impl<'a, const N: usize> BroadcastSmRespBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/cancel_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/cancel_broadcast_sm.rs
@@ -125,27 +125,27 @@ impl<'a, const N: usize> CancelBroadcastSmBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/cancel_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/cancel_sm.rs
@@ -98,7 +98,7 @@ pub struct CancelSm<'a> {
 
 impl<'a> CancelSm<'a> {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub const fn new(
         service_type: ServiceType<'a>,
         message_id: COctetString<'a, 1, 65>,
         source_addr_ton: Ton,
@@ -141,47 +141,47 @@ impl<'a> CancelSmBuilder<'a> {
         Self::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
 
-    pub fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.destination_addr = destination_addr;
         self
     }
 
-    pub fn build(self) -> CancelSm<'a> {
+    pub const fn build(self) -> CancelSm<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/data_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/data_sm.rs
@@ -140,52 +140,52 @@ impl<'a, const N: usize> DataSmBuilder<'a, N> {
         Default::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
 
-    pub fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.destination_addr = destination_addr;
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/deliver_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/deliver_sm.rs
@@ -141,7 +141,7 @@ impl<'a, const N: usize> DeliverSm<'a, N> {
         self.sm_length
     }
 
-    pub fn short_message(&self) -> &OctetString<'a, 0, 255> {
+    pub const fn short_message(&self) -> &OctetString<'a, 0, 255> {
         &self.short_message
     }
 
@@ -197,57 +197,57 @@ impl<'a, const N: usize> DeliverSmBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
 
-    pub fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.destination_addr = destination_addr;
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
 
-    pub fn schedule_delivery_time(
+    pub const fn schedule_delivery_time(
         mut self,
         schedule_delivery_time: EmptyOrFullCOctetString<'a, 17>,
     ) -> Self {
@@ -255,17 +255,20 @@ impl<'a, const N: usize> DeliverSmBuilder<'a, N> {
         self
     }
 
-    pub fn validity_period(mut self, validity_period: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn validity_period(
+        mut self,
+        validity_period: EmptyOrFullCOctetString<'a, 17>,
+    ) -> Self {
         self.inner.validity_period = validity_period;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -273,12 +276,12 @@ impl<'a, const N: usize> DeliverSmBuilder<'a, N> {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/outbind.rs
+++ b/rusmpp-core/src/pdus/borrowed/outbind.rs
@@ -25,7 +25,7 @@ pub struct Outbind<'a> {
 }
 
 impl<'a> Outbind<'a> {
-    pub fn new(system_id: COctetString<'a, 1, 16>, password: COctetString<'a, 1, 9>) -> Self {
+    pub const fn new(system_id: COctetString<'a, 1, 16>, password: COctetString<'a, 1, 9>) -> Self {
         Self {
             system_id,
             password,
@@ -53,17 +53,17 @@ impl<'a> OutbindBuilder<'a> {
         Self::default()
     }
 
-    pub fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
+    pub const fn system_id(mut self, system_id: COctetString<'a, 1, 16>) -> Self {
         self.inner.system_id = system_id;
         self
     }
 
-    pub fn password(mut self, password: COctetString<'a, 1, 9>) -> Self {
+    pub const fn password(mut self, password: COctetString<'a, 1, 9>) -> Self {
         self.inner.password = password;
         self
     }
 
-    pub fn build(self) -> Outbind<'a> {
+    pub const fn build(self) -> Outbind<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/query_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/query_broadcast_sm.rs
@@ -114,22 +114,22 @@ impl<'a> QueryBroadcastSmBuilder<'a> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
@@ -143,7 +143,7 @@ impl<'a> QueryBroadcastSmBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> QueryBroadcastSm<'a> {
+    pub const fn build(self) -> QueryBroadcastSm<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/query_broadcast_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/query_broadcast_sm_resp.rs
@@ -73,7 +73,7 @@ impl<'a, const N: usize> QueryBroadcastSmRespBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/query_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/query_sm.rs
@@ -46,7 +46,7 @@ pub struct QuerySm<'a> {
 }
 
 impl<'a> QuerySm<'a> {
-    pub fn new(
+    pub const fn new(
         message_id: COctetString<'a, 1, 65>,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
@@ -81,27 +81,27 @@ impl<'a> QuerySmBuilder<'a> {
         Default::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn build(self) -> QuerySm<'a> {
+    pub const fn build(self) -> QuerySm<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/query_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/query_sm_resp.rs
@@ -34,7 +34,7 @@ pub struct QuerySmResp<'a> {
 }
 
 impl<'a> QuerySmResp<'a> {
-    pub fn new(
+    pub const fn new(
         message_id: COctetString<'a, 1, 65>,
         final_date: EmptyOrFullCOctetString<'a, 17>,
         message_state: MessageState,
@@ -69,27 +69,27 @@ impl<'a> QuerySmRespBuilder<'a> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn final_date(mut self, final_date: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn final_date(mut self, final_date: EmptyOrFullCOctetString<'a, 17>) -> Self {
         self.inner.final_date = final_date;
         self
     }
 
-    pub fn message_state(mut self, message_state: MessageState) -> Self {
+    pub const fn message_state(mut self, message_state: MessageState) -> Self {
         self.inner.message_state = message_state;
         self
     }
 
-    pub fn error_code(mut self, error_code: u8) -> Self {
+    pub const fn error_code(mut self, error_code: u8) -> Self {
         self.inner.error_code = error_code;
         self
     }
 
-    pub fn build(self) -> QuerySmResp<'a> {
+    pub const fn build(self) -> QuerySmResp<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/replace_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/replace_sm.rs
@@ -117,7 +117,7 @@ impl<'a> ReplaceSm<'a> {
         self.sm_length
     }
 
-    pub fn short_message(&'_ self) -> &'_ OctetString<'_, 0, 255> {
+    pub const fn short_message(&'_ self) -> &'_ OctetString<'_, 0, 255> {
         &self.short_message
     }
 
@@ -177,27 +177,27 @@ impl<'a> ReplaceSmBuilder<'a> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn schedule_delivery_time(
+    pub const fn schedule_delivery_time(
         mut self,
         schedule_delivery_time: EmptyOrFullCOctetString<'a, 17>,
     ) -> Self {
@@ -205,17 +205,20 @@ impl<'a> ReplaceSmBuilder<'a> {
         self
     }
 
-    pub fn validity_period(mut self, validity_period: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn validity_period(
+        mut self,
+        validity_period: EmptyOrFullCOctetString<'a, 17>,
+    ) -> Self {
         self.inner.validity_period = validity_period;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }
@@ -230,7 +233,7 @@ impl<'a> ReplaceSmBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> ReplaceSm<'a> {
+    pub const fn build(self) -> ReplaceSm<'a> {
         self.inner
     }
 }

--- a/rusmpp-core/src/pdus/borrowed/sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/sm_resp.rs
@@ -34,7 +34,7 @@ macro_rules! sm_resp {
                 Self { message_id, tlvs }
             }
 
-            pub fn message_id(&'_ self) -> &'_ COctetString<'a, 1, 65> {
+            pub const fn message_id(&'_ self) -> &'_ COctetString<'a, 1, 65> {
                 &self.message_id
             }
 
@@ -72,7 +72,7 @@ macro_rules! sm_resp {
                     Self::default()
                 }
 
-                pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+                pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
                     self.inner.message_id = message_id;
                     self
                 }

--- a/rusmpp-core/src/pdus/borrowed/submit_multi.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_multi.rs
@@ -233,22 +233,22 @@ impl<'a, const N: usize> SubmitMultiBuilder<'a, N> {
         Default::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
@@ -271,22 +271,22 @@ impl<'a, const N: usize> SubmitMultiBuilder<'a, N> {
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
 
-    pub fn schedule_delivery_time(
+    pub const fn schedule_delivery_time(
         mut self,
         schedule_delivery_time: EmptyOrFullCOctetString<'a, 17>,
     ) -> Self {
@@ -294,17 +294,20 @@ impl<'a, const N: usize> SubmitMultiBuilder<'a, N> {
         self
     }
 
-    pub fn validity_period(mut self, validity_period: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn validity_period(
+        mut self,
+        validity_period: EmptyOrFullCOctetString<'a, 17>,
+    ) -> Self {
         self.inner.validity_period = validity_period;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -312,12 +315,12 @@ impl<'a, const N: usize> SubmitMultiBuilder<'a, N> {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/submit_multi_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_multi_resp.rs
@@ -51,7 +51,7 @@ impl<'a, const N: usize> SubmitMultiResp<'a, N> {
         }
     }
 
-    pub fn no_unsuccess(&self) -> u8 {
+    pub const fn no_unsuccess(&self) -> u8 {
         self.no_unsuccess
     }
 
@@ -119,7 +119,7 @@ impl<'a, const N: usize> SubmitMultiRespBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/submit_sm.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_sm.rs
@@ -135,11 +135,11 @@ impl<'a, const N: usize> SubmitSm<'a, N> {
         }
     }
 
-    pub fn sm_length(&self) -> u8 {
+    pub const fn sm_length(&self) -> u8 {
         self.sm_length
     }
 
-    pub fn short_message(&'_ self) -> &'_ OctetString<'_, 0, 255> {
+    pub const fn short_message(&'_ self) -> &'_ OctetString<'_, 0, 255> {
         &self.short_message
     }
 
@@ -195,57 +195,57 @@ impl<'a, const N: usize> SubmitSmBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
+    pub const fn service_type(mut self, service_type: ServiceType<'a>) -> Self {
         self.inner.service_type = service_type;
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
 
-    pub fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn source_addr(mut self, source_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.source_addr = source_addr;
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
 
-    pub fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
+    pub const fn destination_addr(mut self, destination_addr: COctetString<'a, 1, 21>) -> Self {
         self.inner.destination_addr = destination_addr;
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
 
-    pub fn schedule_delivery_time(
+    pub const fn schedule_delivery_time(
         mut self,
         schedule_delivery_time: EmptyOrFullCOctetString<'a, 17>,
     ) -> Self {
@@ -253,17 +253,20 @@ impl<'a, const N: usize> SubmitSmBuilder<'a, N> {
         self
     }
 
-    pub fn validity_period(mut self, validity_period: EmptyOrFullCOctetString<'a, 17>) -> Self {
+    pub const fn validity_period(
+        mut self,
+        validity_period: EmptyOrFullCOctetString<'a, 17>,
+    ) -> Self {
         self.inner.validity_period = validity_period;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -271,12 +274,12 @@ impl<'a, const N: usize> SubmitSmBuilder<'a, N> {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/borrowed/submit_sm_resp.rs
+++ b/rusmpp-core/src/pdus/borrowed/submit_sm_resp.rs
@@ -31,7 +31,7 @@ impl<'a, const N: usize> SubmitSmResp<'a, N> {
         Self { message_id, tlvs }
     }
 
-    pub fn message_id(&'_ self) -> &'_ COctetString<'_, 1, 65> {
+    pub const fn message_id(&'_ self) -> &'_ COctetString<'_, 1, 65> {
         &self.message_id
     }
 
@@ -76,7 +76,7 @@ impl<'a, const N: usize> SubmitSmRespBuilder<'a, N> {
         Self::default()
     }
 
-    pub fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
+    pub const fn message_id(mut self, message_id: COctetString<'a, 1, 65>) -> Self {
         self.inner.message_id = message_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/alert_notification.rs
+++ b/rusmpp-core/src/pdus/owned/alert_notification.rs
@@ -107,12 +107,12 @@ impl AlertNotificationBuilder {
         Default::default()
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -122,12 +122,12 @@ impl AlertNotificationBuilder {
         self
     }
 
-    pub fn esme_addr_ton(mut self, esme_addr_ton: Ton) -> Self {
+    pub const fn esme_addr_ton(mut self, esme_addr_ton: Ton) -> Self {
         self.inner.esme_addr_ton = esme_addr_ton;
         self
     }
 
-    pub fn esme_addr_npi(mut self, esme_addr_npi: Npi) -> Self {
+    pub const fn esme_addr_npi(mut self, esme_addr_npi: Npi) -> Self {
         self.inner.esme_addr_npi = esme_addr_npi;
         self
     }

--- a/rusmpp-core/src/pdus/owned/broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/owned/broadcast_sm.rs
@@ -162,12 +162,12 @@ impl BroadcastSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -182,7 +182,7 @@ impl BroadcastSmBuilder {
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
@@ -200,7 +200,7 @@ impl BroadcastSmBuilder {
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -208,12 +208,12 @@ impl BroadcastSmBuilder {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/cancel_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/owned/cancel_broadcast_sm.rs
@@ -133,12 +133,12 @@ impl CancelBroadcastSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }

--- a/rusmpp-core/src/pdus/owned/cancel_sm.rs
+++ b/rusmpp-core/src/pdus/owned/cancel_sm.rs
@@ -99,7 +99,7 @@ pub struct CancelSm {
 
 impl CancelSm {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub const fn new(
         service_type: ServiceType,
         message_id: COctetString<1, 65>,
         source_addr_ton: Ton,
@@ -152,12 +152,12 @@ impl CancelSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -167,12 +167,12 @@ impl CancelSmBuilder {
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }

--- a/rusmpp-core/src/pdus/owned/data_sm.rs
+++ b/rusmpp-core/src/pdus/owned/data_sm.rs
@@ -140,12 +140,12 @@ impl DataSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -155,12 +155,12 @@ impl DataSmBuilder {
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
@@ -170,17 +170,17 @@ impl DataSmBuilder {
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }

--- a/rusmpp-core/src/pdus/owned/deliver_sm.rs
+++ b/rusmpp-core/src/pdus/owned/deliver_sm.rs
@@ -141,7 +141,7 @@ impl DeliverSm {
         self.sm_length
     }
 
-    pub fn short_message(&self) -> &OctetString<0, 255> {
+    pub const fn short_message(&self) -> &OctetString<0, 255> {
         &self.short_message
     }
 
@@ -198,12 +198,12 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -213,12 +213,12 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
@@ -228,17 +228,17 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
@@ -256,12 +256,12 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -269,12 +269,12 @@ impl DeliverSmBuilder {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/outbind.rs
+++ b/rusmpp-core/src/pdus/owned/outbind.rs
@@ -26,7 +26,7 @@ pub struct Outbind {
 }
 
 impl Outbind {
-    pub fn new(system_id: COctetString<1, 16>, password: COctetString<1, 9>) -> Self {
+    pub const fn new(system_id: COctetString<1, 16>, password: COctetString<1, 9>) -> Self {
         Self {
             system_id,
             password,

--- a/rusmpp-core/src/pdus/owned/query_broadcast_sm.rs
+++ b/rusmpp-core/src/pdus/owned/query_broadcast_sm.rs
@@ -120,12 +120,12 @@ impl QueryBroadcastSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }

--- a/rusmpp-core/src/pdus/owned/query_sm.rs
+++ b/rusmpp-core/src/pdus/owned/query_sm.rs
@@ -47,7 +47,7 @@ pub struct QuerySm {
 }
 
 impl QuerySm {
-    pub fn new(
+    pub const fn new(
         message_id: COctetString<1, 65>,
         source_addr_ton: Ton,
         source_addr_npi: Npi,
@@ -87,12 +87,12 @@ impl QuerySmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }

--- a/rusmpp-core/src/pdus/owned/query_sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/query_sm_resp.rs
@@ -35,7 +35,7 @@ pub struct QuerySmResp {
 }
 
 impl QuerySmResp {
-    pub fn new(
+    pub const fn new(
         message_id: COctetString<1, 65>,
         final_date: EmptyOrFullCOctetString<17>,
         message_state: MessageState,
@@ -80,12 +80,12 @@ impl QuerySmRespBuilder {
         self
     }
 
-    pub fn message_state(mut self, message_state: MessageState) -> Self {
+    pub const fn message_state(mut self, message_state: MessageState) -> Self {
         self.inner.message_state = message_state;
         self
     }
 
-    pub fn error_code(mut self, error_code: u8) -> Self {
+    pub const fn error_code(mut self, error_code: u8) -> Self {
         self.inner.error_code = error_code;
         self
     }

--- a/rusmpp-core/src/pdus/owned/replace_sm.rs
+++ b/rusmpp-core/src/pdus/owned/replace_sm.rs
@@ -118,7 +118,7 @@ impl ReplaceSm {
         self.sm_length
     }
 
-    pub fn short_message(&self) -> &OctetString<0, 255> {
+    pub const fn short_message(&self) -> &OctetString<0, 255> {
         &self.short_message
     }
 
@@ -183,12 +183,12 @@ impl ReplaceSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -211,12 +211,12 @@ impl ReplaceSmBuilder {
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/sm_resp.rs
@@ -33,7 +33,7 @@ macro_rules! sm_resp {
                 Self { message_id, tlvs }
             }
 
-            pub fn message_id(&self) -> &COctetString<1, 65> {
+            pub const fn message_id(&self) -> &COctetString<1, 65> {
                 &self.message_id
             }
 

--- a/rusmpp-core/src/pdus/owned/submit_multi.rs
+++ b/rusmpp-core/src/pdus/owned/submit_multi.rs
@@ -228,12 +228,12 @@ impl SubmitMultiBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -258,17 +258,17 @@ impl SubmitMultiBuilder {
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
@@ -286,12 +286,12 @@ impl SubmitMultiBuilder {
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -299,12 +299,12 @@ impl SubmitMultiBuilder {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/submit_multi_resp.rs
+++ b/rusmpp-core/src/pdus/owned/submit_multi_resp.rs
@@ -50,7 +50,7 @@ impl SubmitMultiResp {
         }
     }
 
-    pub fn no_unsuccess(&self) -> u8 {
+    pub const fn no_unsuccess(&self) -> u8 {
         self.no_unsuccess
     }
 

--- a/rusmpp-core/src/pdus/owned/submit_sm.rs
+++ b/rusmpp-core/src/pdus/owned/submit_sm.rs
@@ -161,11 +161,11 @@ impl SubmitSm {
         }
     }
 
-    pub fn sm_length(&self) -> u8 {
+    pub const fn sm_length(&self) -> u8 {
         self.sm_length
     }
 
-    pub fn short_message(&self) -> &OctetString<0, 255> {
+    pub const fn short_message(&self) -> &OctetString<0, 255> {
         &self.short_message
     }
 
@@ -234,13 +234,13 @@ impl SubmitSm {
     }
 
     /// Sets the [`SubmitSm::data_coding`].
-    pub fn with_data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn with_data_coding(mut self, data_coding: DataCoding) -> Self {
         self.data_coding = data_coding;
         self
     }
 
     /// Sets the UDH Indicator bit in the GSM Features field of the [`SubmitSm::esm_class`].
-    pub fn with_udhi_indicator(mut self) -> Self {
+    pub const fn with_udhi_indicator(mut self) -> Self {
         self.esm_class = self.esm_class.with_udhi_indicator();
         self
     }
@@ -275,12 +275,12 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
+    pub const fn source_addr_ton(mut self, source_addr_ton: Ton) -> Self {
         self.inner.source_addr_ton = source_addr_ton;
         self
     }
 
-    pub fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
+    pub const fn source_addr_npi(mut self, source_addr_npi: Npi) -> Self {
         self.inner.source_addr_npi = source_addr_npi;
         self
     }
@@ -290,12 +290,12 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
+    pub const fn dest_addr_ton(mut self, dest_addr_ton: Ton) -> Self {
         self.inner.dest_addr_ton = dest_addr_ton;
         self
     }
 
-    pub fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
+    pub const fn dest_addr_npi(mut self, dest_addr_npi: Npi) -> Self {
         self.inner.dest_addr_npi = dest_addr_npi;
         self
     }
@@ -305,17 +305,17 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn esm_class(mut self, esm_class: EsmClass) -> Self {
+    pub const fn esm_class(mut self, esm_class: EsmClass) -> Self {
         self.inner.esm_class = esm_class;
         self
     }
 
-    pub fn protocol_id(mut self, protocol_id: u8) -> Self {
+    pub const fn protocol_id(mut self, protocol_id: u8) -> Self {
         self.inner.protocol_id = protocol_id;
         self
     }
 
-    pub fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
+    pub const fn priority_flag(mut self, priority_flag: PriorityFlag) -> Self {
         self.inner.priority_flag = priority_flag;
         self
     }
@@ -333,12 +333,12 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
+    pub const fn registered_delivery(mut self, registered_delivery: RegisteredDelivery) -> Self {
         self.inner.registered_delivery = registered_delivery;
         self
     }
 
-    pub fn replace_if_present_flag(
+    pub const fn replace_if_present_flag(
         mut self,
         replace_if_present_flag: ReplaceIfPresentFlag,
     ) -> Self {
@@ -346,12 +346,12 @@ impl SubmitSmBuilder {
         self
     }
 
-    pub fn data_coding(mut self, data_coding: DataCoding) -> Self {
+    pub const fn data_coding(mut self, data_coding: DataCoding) -> Self {
         self.inner.data_coding = data_coding;
         self
     }
 
-    pub fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
+    pub const fn sm_default_msg_id(mut self, sm_default_msg_id: u8) -> Self {
         self.inner.sm_default_msg_id = sm_default_msg_id;
         self
     }

--- a/rusmpp-core/src/pdus/owned/submit_sm_resp.rs
+++ b/rusmpp-core/src/pdus/owned/submit_sm_resp.rs
@@ -31,7 +31,7 @@ impl SubmitSmResp {
         Self { message_id, tlvs }
     }
 
-    pub fn message_id(&self) -> &COctetString<1, 65> {
+    pub const fn message_id(&self) -> &COctetString<1, 65> {
         &self.message_id
     }
 

--- a/rusmpp-core/src/tokio_codec/mod.rs
+++ b/rusmpp-core/src/tokio_codec/mod.rs
@@ -49,13 +49,13 @@ impl CommandCodec {
     }
 
     #[inline]
-    pub fn with_max_length(mut self, max_length: usize) -> Self {
+    pub const fn with_max_length(mut self, max_length: usize) -> Self {
         self.max_length = Some(max_length);
         self
     }
 
     #[inline]
-    pub fn without_max_length(mut self) -> Self {
+    pub const fn without_max_length(mut self) -> Self {
         self.max_length = None;
         self
     }

--- a/rusmpp-core/src/types/borrowed/any_octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/any_octet_string.rs
@@ -57,7 +57,7 @@ impl<'a> AnyOctetString<'a> {
 
     /// Interprets the [`AnyOctetString`] as &[`str`].
     #[inline]
-    pub fn to_str(&self) -> Result<&str, core::str::Utf8Error> {
+    pub const fn to_str(&self) -> Result<&str, core::str::Utf8Error> {
         core::str::from_utf8(self.bytes)
     }
 }

--- a/rusmpp-core/src/types/borrowed/octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/octet_string.rs
@@ -118,7 +118,7 @@ impl<'a, const MIN: usize, const MAX: usize> OctetString<'a, MIN, MAX> {
 
     /// Interprets the [`OctetString`] as &[`str`].
     #[inline]
-    pub fn to_str(&self) -> Result<&str, core::str::Utf8Error> {
+    pub const fn to_str(&self) -> Result<&str, core::str::Utf8Error> {
         core::str::from_utf8(self.bytes)
     }
 }

--- a/rusmpp-core/src/types/owned/any_octet_string.rs
+++ b/rusmpp-core/src/types/owned/any_octet_string.rs
@@ -45,13 +45,13 @@ impl AnyOctetString {
     ///
     /// Equivalent to [`AnyOctetString::empty`].
     #[inline]
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self::empty()
     }
 
     /// Creates a new empty [`AnyOctetString`].
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             bytes: Bytes::new(),
         }
@@ -59,7 +59,7 @@ impl AnyOctetString {
 
     /// Returns the number of bytes contained in the [`AnyOctetString`].
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.bytes.len()
     }
 
@@ -68,13 +68,13 @@ impl AnyOctetString {
     /// An [`AnyOctetString`] is considered empty if it
     /// contains no octets.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.bytes.is_empty()
     }
 
     /// Creates a new [`AnyOctetString`] from [`Bytes`].
     #[inline]
-    pub fn from_bytes(bytes: Bytes) -> Self {
+    pub const fn from_bytes(bytes: Bytes) -> Self {
         Self { bytes }
     }
 
@@ -91,14 +91,14 @@ impl AnyOctetString {
     /// Creates a new [`AnyOctetString`] from `&'static [u8]`.
     ///
     /// This function does not copy or allocate.
-    pub fn from_static_slice(bytes: &'static [u8]) -> Self {
+    pub const fn from_static_slice(bytes: &'static [u8]) -> Self {
         Self::from_bytes(Bytes::from_static(bytes))
     }
 
     /// Creates a new [`AnyOctetString`] from `&'static` [`str`].
     ///
     /// This function does not copy or allocate.
-    pub fn from_static_str(str: &'static str) -> Self {
+    pub const fn from_static_str(str: &'static str) -> Self {
         Self::from_bytes(Bytes::from_static(str.as_bytes()))
     }
 

--- a/rusmpp-core/src/types/owned/c_octet_string.rs
+++ b/rusmpp-core/src/types/owned/c_octet_string.rs
@@ -123,7 +123,7 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
     ///
     /// Equivalent to [`COctetString::empty`].
     #[inline]
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self::_ASSERT_VALID;
 
         Self::empty()
@@ -131,7 +131,7 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
 
     /// Creates a new empty [`COctetString`].
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::_ASSERT_VALID;
 
         Self {
@@ -141,7 +141,7 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
 
     /// Returns the number of bytes contained in the [`COctetString`] including the null terminator.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.bytes.len()
     }
 
@@ -150,7 +150,7 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
     /// A [`COctetString`] is considered empty if it
     /// contains only a single NULL octet (0x00).
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 1
     }
 
@@ -233,7 +233,7 @@ impl<const MIN: usize, const MAX: usize> COctetString<MIN, MAX> {
 
     /// Creates a new [`COctetString`] from `&'static [u8]` without checking the length and the null terminator.
     #[inline]
-    pub(crate) fn from_static_slice_unchecked(bytes: &'static [u8]) -> Self {
+    pub(crate) const fn from_static_slice_unchecked(bytes: &'static [u8]) -> Self {
         Self::_ASSERT_VALID;
 
         Self {

--- a/rusmpp-core/src/types/owned/empty_or_full_c_octet_string.rs
+++ b/rusmpp-core/src/types/owned/empty_or_full_c_octet_string.rs
@@ -72,7 +72,7 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
     ///
     /// Equivalent to [`EmptyOrFullCOctetString::empty`].
     #[inline]
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self::_ASSERT_VALID;
 
         Self::empty()
@@ -80,7 +80,7 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
 
     /// Creates a new empty [`EmptyOrFullCOctetString`].
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::_ASSERT_VALID;
 
         Self {
@@ -90,7 +90,7 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
 
     /// Returns the number of bytes contained in the [`EmptyOrFullCOctetString`] including the null terminator.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.bytes.len()
     }
 
@@ -99,7 +99,7 @@ impl<const N: usize> EmptyOrFullCOctetString<N> {
     /// An [`EmptyOrFullCOctetString`] is considered empty if it
     /// contains only a single NULL octet `(0x00)`.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 1
     }
 

--- a/rusmpp-core/src/types/owned/octet_string.rs
+++ b/rusmpp-core/src/types/owned/octet_string.rs
@@ -88,7 +88,7 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
     ///
     /// Equivalent to [`OctetString::empty`].
     #[inline]
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self::_ASSERT_VALID;
 
         Self::empty()
@@ -96,7 +96,7 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
 
     /// Creates a new empty [`OctetString`].
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self::_ASSERT_VALID;
 
         Self {
@@ -106,7 +106,7 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
 
     /// Returns the number of bytes contained in the [`OctetString`].
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.bytes.len()
     }
 
@@ -115,7 +115,7 @@ impl<const MIN: usize, const MAX: usize> OctetString<MIN, MAX> {
     /// An [`OctetString`] is considered empty if it
     /// contains no octets.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.bytes.is_empty()
     }
 

--- a/rusmpp-core/src/values/broadcast_area_identifier/borrowed.rs
+++ b/rusmpp-core/src/values/broadcast_area_identifier/borrowed.rs
@@ -16,7 +16,7 @@ pub struct BroadcastAreaIdentifier<'a> {
 }
 
 impl<'a> BroadcastAreaIdentifier<'a> {
-    pub fn new(format: BroadcastAreaFormat, area: AnyOctetString<'a>) -> Self {
+    pub const fn new(format: BroadcastAreaFormat, area: AnyOctetString<'a>) -> Self {
         Self { format, area }
     }
 }

--- a/rusmpp-core/src/values/broadcast_area_identifier/owned.rs
+++ b/rusmpp-core/src/values/broadcast_area_identifier/owned.rs
@@ -17,7 +17,7 @@ pub struct BroadcastAreaIdentifier {
 }
 
 impl BroadcastAreaIdentifier {
-    pub fn new(format: BroadcastAreaFormat, area: AnyOctetString) -> Self {
+    pub const fn new(format: BroadcastAreaFormat, area: AnyOctetString) -> Self {
         Self { format, area }
     }
 }

--- a/rusmpp-core/src/values/broadcast_content_type.rs
+++ b/rusmpp-core/src/values/broadcast_content_type.rs
@@ -79,7 +79,10 @@ pub struct BroadcastContentType {
 }
 
 impl BroadcastContentType {
-    pub fn new(type_of_network: TypeOfNetwork, encoding_content_type: EncodingContentType) -> Self {
+    pub const fn new(
+        type_of_network: TypeOfNetwork,
+        encoding_content_type: EncodingContentType,
+    ) -> Self {
         Self {
             type_of_network,
             encoding_content_type,

--- a/rusmpp-core/src/values/broadcast_frequency_interval.rs
+++ b/rusmpp-core/src/values/broadcast_frequency_interval.rs
@@ -30,7 +30,7 @@ pub struct BroadcastFrequencyInterval {
 }
 
 impl BroadcastFrequencyInterval {
-    pub fn new(unit: UnitOfTime, value: u16) -> Self {
+    pub const fn new(unit: UnitOfTime, value: u16) -> Self {
         Self { unit, value }
     }
 }

--- a/rusmpp-core/src/values/callback_num_pres_ind.rs
+++ b/rusmpp-core/src/values/callback_num_pres_ind.rs
@@ -11,7 +11,7 @@ pub struct CallbackNumPresInd {
 }
 
 impl CallbackNumPresInd {
-    pub fn new(presentation: Presentation, screening: Screening) -> Self {
+    pub const fn new(presentation: Presentation, screening: Screening) -> Self {
         Self {
             presentation,
             screening,

--- a/rusmpp-core/src/values/esm_class.rs
+++ b/rusmpp-core/src/values/esm_class.rs
@@ -24,7 +24,7 @@ pub struct EsmClass {
 }
 
 impl EsmClass {
-    pub fn new(
+    pub const fn new(
         messaging_mode: MessagingMode,
         message_type: MessageType,
         ansi41_specific: Ansi41Specific,

--- a/rusmpp-core/src/values/its_session_info.rs
+++ b/rusmpp-core/src/values/its_session_info.rs
@@ -10,7 +10,7 @@ pub struct ItsSessionInfo {
 }
 
 impl ItsSessionInfo {
-    pub fn new(session_number: u8, sequence_number: u8) -> Self {
+    pub const fn new(session_number: u8, sequence_number: u8) -> Self {
         Self {
             session_number,
             sequence_number,

--- a/rusmpp-core/src/values/ms_msg_wait_facilities.rs
+++ b/rusmpp-core/src/values/ms_msg_wait_facilities.rs
@@ -11,7 +11,7 @@ pub struct MsMsgWaitFacilities {
 }
 
 impl MsMsgWaitFacilities {
-    pub fn new(indicator: Indicator, type_of_message: TypeOfMessage) -> Self {
+    pub const fn new(indicator: Indicator, type_of_message: TypeOfMessage) -> Self {
         Self {
             indicator,
             type_of_message,

--- a/rusmpp-core/src/values/ms_validity.rs
+++ b/rusmpp-core/src/values/ms_validity.rs
@@ -11,7 +11,7 @@ pub struct MsValidity {
 }
 
 impl MsValidity {
-    pub fn new(
+    pub const fn new(
         validity_behavior: MsValidityBehavior,
         validity_information: Option<MsValidityInformation>,
     ) -> Self {
@@ -32,7 +32,7 @@ pub struct MsValidityInformation {
 }
 
 impl MsValidityInformation {
-    pub fn new(units_of_time: UnitsOfTime, number_of_time_units: u16) -> Self {
+    pub const fn new(units_of_time: UnitsOfTime, number_of_time_units: u16) -> Self {
         Self {
             units_of_time,
             number_of_time_units,

--- a/rusmpp-core/src/values/network_error_code.rs
+++ b/rusmpp-core/src/values/network_error_code.rs
@@ -10,7 +10,7 @@ pub struct NetworkErrorCode {
 }
 
 impl NetworkErrorCode {
-    pub fn new(network_type: ErrorCodeNetworkType, error_code: u16) -> Self {
+    pub const fn new(network_type: ErrorCodeNetworkType, error_code: u16) -> Self {
         Self {
             network_type,
             error_code,

--- a/rusmpp-core/src/values/priority_flag.rs
+++ b/rusmpp-core/src/values/priority_flag.rs
@@ -11,7 +11,7 @@ pub struct PriorityFlag {
 }
 
 impl PriorityFlag {
-    pub fn new(value: u8) -> Self {
+    pub const fn new(value: u8) -> Self {
         Self { value }
     }
 }

--- a/rusmpp-core/src/values/registered_delivery.rs
+++ b/rusmpp-core/src/values/registered_delivery.rs
@@ -13,7 +13,7 @@ pub struct RegisteredDelivery {
 }
 
 impl RegisteredDelivery {
-    pub fn new(
+    pub const fn new(
         mc_delivery_receipt: MCDeliveryReceipt,
         sme_originated_acknowledgement: SmeOriginatedAcknowledgement,
         intermediate_notification: IntermediateNotification,
@@ -31,7 +31,7 @@ impl RegisteredDelivery {
     }
 
     /// Request all delivery receipts, acknowledgements and notifications
-    pub fn request_all() -> Self {
+    pub const fn request_all() -> Self {
         Self::new(
             MCDeliveryReceipt::McDeliveryReceiptRequestedWhereFinalDeliveryOutcomeIsSuccessOrFailure,
             SmeOriginatedAcknowledgement::BothDeliveryAndUserAcknowledgmentRequested,
@@ -40,19 +40,19 @@ impl RegisteredDelivery {
         )
     }
 
-    pub fn mc_delivery_receipt(&self) -> MCDeliveryReceipt {
+    pub const fn mc_delivery_receipt(&self) -> MCDeliveryReceipt {
         self.mc_delivery_receipt
     }
 
-    pub fn sme_originated_acknowledgement(&self) -> SmeOriginatedAcknowledgement {
+    pub const fn sme_originated_acknowledgement(&self) -> SmeOriginatedAcknowledgement {
         self.sme_originated_acknowledgement
     }
 
-    pub fn intermediate_notification(&self) -> IntermediateNotification {
+    pub const fn intermediate_notification(&self) -> IntermediateNotification {
         self.intermediate_notification
     }
 
-    pub fn other(&self) -> u8 {
+    pub const fn other(&self) -> u8 {
         self.other
     }
 }

--- a/rusmpp-core/src/values/service_type/owned.rs
+++ b/rusmpp-core/src/values/service_type/owned.rs
@@ -75,7 +75,7 @@ impl ServiceType {
     }
 
     /// Create a new [`ServiceType`] with a value of 0.
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self {
             value: COctetString::null(),
         }

--- a/rusmpp-core/src/values/sub_address/borrowed.rs
+++ b/rusmpp-core/src/values/sub_address/borrowed.rs
@@ -15,7 +15,7 @@ pub struct Subaddress<'a> {
 }
 
 impl<'a> Subaddress<'a> {
-    pub fn new(tag: SubaddressTag, addr: OctetString<'a, 1, 22>) -> Self {
+    pub const fn new(tag: SubaddressTag, addr: OctetString<'a, 1, 22>) -> Self {
         Self { tag, addr }
     }
 }

--- a/rusmpp-core/src/values/sub_address/owned.rs
+++ b/rusmpp-core/src/values/sub_address/owned.rs
@@ -16,7 +16,7 @@ pub struct Subaddress {
 }
 
 impl Subaddress {
-    pub fn new(tag: SubaddressTag, addr: OctetString<1, 22>) -> Self {
+    pub const fn new(tag: SubaddressTag, addr: OctetString<1, 22>) -> Self {
         Self { tag, addr }
     }
 }

--- a/rusmpp-core/src/values/unsuccess_sme/borrowed.rs
+++ b/rusmpp-core/src/values/unsuccess_sme/borrowed.rs
@@ -33,7 +33,7 @@ impl Default for UnsuccessSme<'_> {
 }
 
 impl<'a> UnsuccessSme<'a> {
-    pub fn new(
+    pub const fn new(
         dest_addr_ton: Ton,
         dest_addr_npi: Npi,
         destination_addr: COctetString<'a, 1, 21>,

--- a/rusmpp-core/src/values/unsuccess_sme/owned.rs
+++ b/rusmpp-core/src/values/unsuccess_sme/owned.rs
@@ -34,7 +34,7 @@ impl Default for UnsuccessSme {
 }
 
 impl UnsuccessSme {
-    pub fn new(
+    pub const fn new(
         dest_addr_ton: Ton,
         dest_addr_npi: Npi,
         destination_addr: COctetString<1, 21>,


### PR DESCRIPTION
### Summary
- Make every function const where possible inside of rumspp-core

- add `#![deny(clippy::missing_const_for_fn)]` to rumpp-core `lib.rs`


### Execution
```
cargo clippy --workspace --fix --allow-dirty
```

### Next 
Do the same for the other crates


> Refs: #21