### PR TITLE
refactor(rusmpp-core/types/strings)!: impl Debug for String now only prints the bytes

### DIFF
--- a/rusmpp-core/src/types/borrowed/any_octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/any_octet_string.rs
@@ -64,10 +64,7 @@ impl<'a> AnyOctetString<'a> {
 
 impl core::fmt::Debug for AnyOctetString<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AnyOctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_str().unwrap_or("<invalid utf-8>"))
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 

--- a/rusmpp-core/src/types/borrowed/c_octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/c_octet_string.rs
@@ -181,10 +181,7 @@ impl<'a, const MIN: usize, const MAX: usize> COctetString<'a, MIN, MAX> {
 
 impl<const MIN: usize, const MAX: usize> core::fmt::Debug for COctetString<'_, MIN, MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("COctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.as_str())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 

--- a/rusmpp-core/src/types/borrowed/empty_or_full_c_octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/empty_or_full_c_octet_string.rs
@@ -134,10 +134,7 @@ impl<'a, const N: usize> EmptyOrFullCOctetString<'a, N> {
 
 impl<const N: usize> core::fmt::Debug for EmptyOrFullCOctetString<'_, N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EmptyOrFullCOctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.as_str())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 

--- a/rusmpp-core/src/types/borrowed/octet_string.rs
+++ b/rusmpp-core/src/types/borrowed/octet_string.rs
@@ -125,10 +125,7 @@ impl<'a, const MIN: usize, const MAX: usize> OctetString<'a, MIN, MAX> {
 
 impl<const MIN: usize, const MAX: usize> core::fmt::Debug for OctetString<'_, MIN, MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_str().unwrap_or("<invalid utf-8>"))
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 

--- a/rusmpp-core/src/types/owned/any_octet_string.rs
+++ b/rusmpp-core/src/types/owned/any_octet_string.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
@@ -145,10 +145,7 @@ impl From<AnyOctetString> for Vec<u8> {
 
 impl core::fmt::Debug for AnyOctetString {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AnyOctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_string())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 

--- a/rusmpp-core/src/types/owned/c_octet_string.rs
+++ b/rusmpp-core/src/types/owned/c_octet_string.rs
@@ -1,6 +1,6 @@
 #![allow(path_statements)]
 
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
@@ -281,10 +281,7 @@ impl<const MIN: usize, const MAX: usize> Default for COctetString<MIN, MAX> {
 
 impl<const MIN: usize, const MAX: usize> core::fmt::Debug for COctetString<MIN, MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("COctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_string())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 
@@ -636,6 +633,8 @@ mod tests {
     }
 
     mod as_str {
+        use alloc::string::ToString;
+
         use super::*;
 
         #[test]

--- a/rusmpp-core/src/types/owned/empty_or_full_c_octet_string.rs
+++ b/rusmpp-core/src/types/owned/empty_or_full_c_octet_string.rs
@@ -1,6 +1,6 @@
 #![allow(path_statements)]
 
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
@@ -231,10 +231,7 @@ impl<const N: usize> Default for EmptyOrFullCOctetString<N> {
 
 impl<const N: usize> core::fmt::Debug for EmptyOrFullCOctetString<N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EmptyOrFullCOctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_string())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 
@@ -535,6 +532,8 @@ mod tests {
     }
 
     mod as_str {
+        use alloc::string::ToString;
+
         use super::*;
 
         #[test]

--- a/rusmpp-core/src/types/owned/octet_string.rs
+++ b/rusmpp-core/src/types/owned/octet_string.rs
@@ -1,5 +1,5 @@
 #![allow(path_statements)]
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
@@ -219,10 +219,7 @@ impl<const MIN: usize, const MAX: usize> From<OctetString<MIN, MAX>> for Vec<u8>
 
 impl<const MIN: usize, const MAX: usize> core::fmt::Debug for OctetString<MIN, MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OctetString")
-            .field("bytes", &self.bytes)
-            .field("string", &self.to_string())
-            .finish()
+        core::fmt::Debug::fmt(&self.bytes, f)
     }
 }
 


### PR DESCRIPTION
The string representation was too noisy